### PR TITLE
修正首次打开页面报请求失败的提示

### DIFF
--- a/web_src/src/components/control.vue
+++ b/web_src/src/components/control.vue
@@ -137,15 +137,13 @@ export default {
     mounted() {
 
         this.initTable();
-        this.updateData();
         this.chartInterval = setInterval(this.updateData, 3000);
         this.mediaServer.getOnlineMediaServerList((data)=>{
           this.mediaServerList = data.data;
           if (this.mediaServerList && this.mediaServerList.length > 0) {
             this.mediaServerChoose = this.mediaServerList[0].id
             this.loadCount = this.mediaServerList[0].count;
-            this.getThreadsLoad();
-            this.getAllSession();
+            this.updateData();
           }
         })
     },


### PR DESCRIPTION
mediaServerChoose获取到之前，执行updateData, 会导致getAllSession函数获取不到mediaServerChoose。