### PR TITLE
判断当前页面协议选择播放连接

### DIFF
--- a/web_src/src/components/live.vue
+++ b/web_src/src/components/live.vue
@@ -178,7 +178,11 @@
           console.log(res)
           if (res.data.code == 0 && res.data.data) {
             itemData.playUrl = res.data.data.httpsFlv
-            that.setPlayUrl(res.data.data.ws_flv,idxTmp)
+            if(window.location.protocol === 'https:'){
+              that.setPlayUrl(res.data.data.wss_flv,idxTmp)
+            } else {
+              that.setPlayUrl(res.data.data.ws_flv,idxTmp)
+            }
           }else {
             that.$message.error(res.data.msg);
           }


### PR DESCRIPTION
在https页面下会因为使用ws_flv连接导致播放失败, 所以对当前页面的协议进行判断