### PR TITLE
fixed--多节点管理zlm,wvp重启之后节点中的redis在线状态bug修复

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/media/zlm/ZLMRunner.java
+++ b/src/main/java/com/genersoft/iot/vmp/media/zlm/ZLMRunner.java
@@ -92,6 +92,7 @@ public class ZLMRunner implements CommandLineRunner {
 
         // 获取所有的zlm， 并开启主动连接
         List<MediaServerItem> all = mediaServerService.getAllFromDatabase();
+        mediaServerService.updateVmServer(all);
         if (all.size() == 0) {
             all.add(mediaConfig.getMediaSerItem());
         }

--- a/src/main/java/com/genersoft/iot/vmp/service/IMediaServerService.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/IMediaServerService.java
@@ -76,6 +76,8 @@ public interface IMediaServerService {
 
     void delete(String id);
 
+    void deleteDb(String id);
+
     MediaServerItem getDefaultMediaServer();
 
     void updateMediaServerKeepalive(String mediaServerId, JSONObject data);

--- a/src/main/java/com/genersoft/iot/vmp/service/IMediaServerService.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/IMediaServerService.java
@@ -42,6 +42,8 @@ public interface IMediaServerService {
 
     void setZLMConfig(MediaServerItem mediaServerItem, boolean restart);
 
+    void updateVmServer(List<MediaServerItem>  mediaServerItemList);
+
     SSRCInfo openRTPServer(MediaServerItem mediaServerItem, String streamId);
 
     SSRCInfo openRTPServer(MediaServerItem mediaServerItem, String streamId, boolean isPlayback);

--- a/src/main/java/com/genersoft/iot/vmp/service/impl/MediaServerServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/impl/MediaServerServiceImpl.java
@@ -46,8 +46,7 @@ import java.util.*;
  * 媒体服务器节点管理
  */
 @Service
-@Order(value=2)
-public class MediaServerServiceImpl implements IMediaServerService, CommandLineRunner {
+public class MediaServerServiceImpl implements IMediaServerService {
 
     private final static Logger logger = LoggerFactory.getLogger(MediaServerServiceImpl.class);
 
@@ -102,9 +101,8 @@ public class MediaServerServiceImpl implements IMediaServerService, CommandLineR
      * 初始化
      */
     @Override
-    public void run(String... args) throws Exception {
+    public void updateVmServer(List<MediaServerItem>  mediaServerItemList) {
         logger.info("[缓存初始化] Media Server ");
-        List<MediaServerItem> mediaServerItemList = mediaServerMapper.queryAll();
         for (MediaServerItem mediaServerItem : mediaServerItemList) {
             if (StringUtils.isEmpty(mediaServerItem.getId())) {
                 continue;
@@ -224,7 +222,8 @@ public class MediaServerServiceImpl implements IMediaServerService, CommandLineR
             String key = (String) mediaServerKey;
             MediaServerItem mediaServerItem = (MediaServerItem) redisUtil.get(key);
             // 检查状态
-            if (redisUtil.zScore(onlineKey, mediaServerItem.getId()) != null) {
+            Double aDouble = redisUtil.zScore(onlineKey, mediaServerItem.getId());
+            if (aDouble != null) {
                 mediaServerItem.setStatus(true);
             }
             result.add(mediaServerItem);

--- a/src/main/java/com/genersoft/iot/vmp/service/impl/MediaServerServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/impl/MediaServerServiceImpl.java
@@ -608,6 +608,11 @@ public class MediaServerServiceImpl implements IMediaServerService {
         String key = VideoManagerConstants.MEDIA_SERVER_PREFIX + userSetup.getServerId() + "_" + id;
         redisUtil.del(key);
     }
+    @Override
+    public void deleteDb(String id){
+        //同步删除数据库中的数据
+        mediaServerMapper.delOne(id);
+    }
 
     @Override
     public void updateMediaServerKeepalive(String mediaServerId, JSONObject data) {

--- a/src/main/java/com/genersoft/iot/vmp/vmanager/server/ServerController.java
+++ b/src/main/java/com/genersoft/iot/vmp/vmanager/server/ServerController.java
@@ -158,6 +158,7 @@ public class ServerController {
     public WVPResult<String> deleteMediaServer(@RequestParam  String id){
         if (mediaServerService.getOne(id) != null) {
             mediaServerService.delete(id);
+            mediaServerService.deleteDb(id);
         }else {
             WVPResult<String> result = new WVPResult<>();
             result.setCode(-1);


### PR DESCRIPTION
fixed--多节点管理zlm,wvp重启之后节点中的redis在线状态bug修复。
主要原因为代码：
getMediaServerConfig方法中这个判断
!mediaServerItem.isDefaultServer() && **mediaServerService.getOne(mediaServerItem.getId()) == null**
导致了添加的节点不会去进行重上线的连接
