### PR TITLE
fixed--设备刷新超时时间设置为3s

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/vmanager/gb28181/device/DeviceQuery.java
+++ b/src/main/java/com/genersoft/iot/vmp/vmanager/gb28181/device/DeviceQuery.java
@@ -153,8 +153,8 @@ public class DeviceQuery {
 		Device device = storager.queryVideoDevice(deviceId);
 		String key = DeferredResultHolder.CALLBACK_CMD_CATALOG + deviceId;
 		String uuid = UUID.randomUUID().toString();
-		// 默认超时时间为30分钟
-		DeferredResult<ResponseEntity<Device>> result = new DeferredResult<ResponseEntity<Device>>(30*60*1000L);
+		// 默认超时时间为3秒钟
+		DeferredResult<ResponseEntity<Device>> result = new DeferredResult<ResponseEntity<Device>>(3000L);
 		result.onTimeout(()->{
 			logger.warn("设备[{}]通道信息同步超时", deviceId);
 			// 释放rtpserver


### PR DESCRIPTION
设备刷新超时时间设置为3s,之前为30分钟，个人认为该项时间过久，部分设备不支持该协议的时候，导致体验很差，不知道作者是怎么考虑的。