### PR TITLE
级联场景，invite消息中获取channelid。以前从invite的第一行读取，现在从subject header读取。

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/InviteRequestProcessor.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/InviteRequestProcessor.java
@@ -26,6 +26,7 @@ import gov.nist.javax.sdp.TimeDescriptionImpl;
 import gov.nist.javax.sdp.fields.TimeField;
 import gov.nist.javax.sip.address.AddressImpl;
 import gov.nist.javax.sip.address.SipUri;
+import gov.nist.javax.sip.header.Subject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -40,6 +41,7 @@ import javax.sip.SipException;
 import javax.sip.address.SipURI;
 import javax.sip.header.CallIdHeader;
 import javax.sip.header.FromHeader;
+import javax.sip.header.Header;
 import javax.sip.message.Request;
 import javax.sip.message.Response;
 import java.text.ParseException;
@@ -105,7 +107,9 @@ public class InviteRequestProcessor extends SIPRequestProcessorParent implements
 		try {
 			Request request = evt.getRequest();
 			SipURI sipURI = (SipURI) request.getRequestURI();
-			String channelId = sipURI.getUser();
+			//从subject读取channelId,不再从request-line读取。 有些平台request-line是平台国标编码，不是设备国标编码。
+			//String channelId = sipURI.getUser();
+			String channelId = SipUtils.getChannelIdFromHeader(request);
 			String requesterId = SipUtils.getUserIdFromFromHeader(request);
 			CallIdHeader callIdHeader = (CallIdHeader)request.getHeader(CallIdHeader.NAME);
 			if (requesterId == null || channelId == null) {

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/utils/SipUtils.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/utils/SipUtils.java
@@ -2,8 +2,10 @@ package com.genersoft.iot.vmp.gb28181.utils;
 
 import gov.nist.javax.sip.address.AddressImpl;
 import gov.nist.javax.sip.address.SipUri;
+import gov.nist.javax.sip.header.Subject;
 
 import javax.sip.header.FromHeader;
+import javax.sip.header.Header;
 import javax.sip.message.Request;
 
 /**
@@ -17,6 +19,13 @@ public class SipUtils {
     public static String getUserIdFromFromHeader(Request request) {
         FromHeader fromHeader = (FromHeader)request.getHeader(FromHeader.NAME);
         return getUserIdFromFromHeader(fromHeader);
+    }
+    /**
+     * 从subject读取channelId
+     * */
+    public static String getChannelIdFromHeader(Request request) {
+        Header subject = request.getHeader("subject");
+        return ((Subject) subject).getSubject().split(":")[0];
     }
 
     public static String getUserIdFromFromHeader(FromHeader fromHeader) {


### PR DESCRIPTION
InviteRequestProcessor类中，channelid从invite消息的header subject获取，不再从第一行request line获取。原因是和第三方平台对接时，发送的invite消息第一行为国标平台编码而不是设备通道编码，导致报错通道不存在，返回404。