### PR TITLE
优化摄像头注册流程

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/RegisterRequestProcessor.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/RegisterRequestProcessor.java
@@ -3,7 +3,6 @@ package com.genersoft.iot.vmp.gb28181.transmit.event.request.impl;
 import com.genersoft.iot.vmp.common.VideoManagerConstants;
 import com.genersoft.iot.vmp.conf.SipConfig;
 import com.genersoft.iot.vmp.gb28181.auth.DigestServerAuthenticationHelper;
-import com.genersoft.iot.vmp.gb28181.auth.RegisterLogicHandler;
 import com.genersoft.iot.vmp.gb28181.bean.Device;
 import com.genersoft.iot.vmp.gb28181.bean.WvpSipDate;
 import com.genersoft.iot.vmp.gb28181.event.EventPublisher;
@@ -42,166 +41,157 @@ import java.util.Locale;
 @Component
 public class RegisterRequestProcessor extends SIPRequestProcessorParent implements InitializingBean, ISIPRequestProcessor {
 
-	private Logger logger = LoggerFactory.getLogger(RegisterRequestProcessor.class);
+    private final Logger logger = LoggerFactory.getLogger(RegisterRequestProcessor.class);
 
-	public String method = "REGISTER";
+    public String method = "REGISTER";
 
-	@Autowired
-	private SipConfig sipConfig;
+    @Autowired
+    private SipConfig sipConfig;
 
-	@Autowired
-	private RegisterLogicHandler handler;
+    @Autowired
+    private IRedisCatchStorage redisCatchStorage;
 
-	@Autowired
-	private IRedisCatchStorage redisCatchStorage;
+    @Autowired
+    private IVideoManagerStorage storager;
 
-	@Autowired
-	private IVideoManagerStorage storager;
+    @Autowired
+    private EventPublisher publisher;
 
-	@Autowired
-	private EventPublisher publisher;
+    @Autowired
+    private SIPProcessorObserver sipProcessorObserver;
 
-	@Autowired
-	private SIPProcessorObserver sipProcessorObserver;
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        // 添加消息处理的订阅
+        sipProcessorObserver.addRequestProcessor(method, this);
+    }
 
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		// 添加消息处理的订阅
-		sipProcessorObserver.addRequestProcessor(method, this);
-	}
+    /**
+     * 收到注册请求 处理
+     *
+     * @param evt
+     */
+    @Override
+    public void process(RequestEvent evt) {
+        try {
+            RequestEventExt evtExt = (RequestEventExt) evt;
+            String requestAddress = evtExt.getRemoteIpAddress() + ":" + evtExt.getRemotePort();
+            logger.info("[{}] 收到注册请求，开始处理", requestAddress);
+            Request request = evt.getRequest();
+            ExpiresHeader expiresHeader = (ExpiresHeader) request.getHeader(Expires.NAME);
+            Response response = null;
+            boolean passwordCorrect = false;
+            // 注册标志  0：未携带授权头或者密码错误  1：注册成功   2：注销成功
+            int registerFlag = 0;
+            FromHeader fromHeader = (FromHeader) request.getHeader(FromHeader.NAME);
+            AddressImpl address = (AddressImpl) fromHeader.getAddress();
+            SipUri uri = (SipUri) address.getURI();
+            String deviceId = uri.getUser();
 
-	/**
-	 * 收到注册请求 处理
- 	 * @param evt
-	 */
-	@Override
-	public void process(RequestEvent evt) {
-		try {
-			RequestEventExt evtExt = (RequestEventExt)evt;
-			String requestAddress = evtExt.getRemoteIpAddress() + ":" + evtExt.getRemotePort();
-			logger.info("[{}] 收到注册请求，开始处理", requestAddress);
-			Request request = evt.getRequest();
-			ExpiresHeader expiresHeader = (ExpiresHeader) request.getHeader(Expires.NAME);
-			Response response = null; 
-			boolean passwordCorrect = false;
-			// 注册标志  0：未携带授权头或者密码错误  1：注册成功   2：注销成功
-			int registerFlag = 0;
-			FromHeader fromHeader = (FromHeader) request.getHeader(FromHeader.NAME);
-			AddressImpl address = (AddressImpl) fromHeader.getAddress();
-			SipUri uri = (SipUri) address.getURI();
-			String deviceId = uri.getUser();
-			Device deviceInRedis = redisCatchStorage.getDevice(deviceId);
-			Device device = storager.queryVideoDevice(deviceId);
-			if (deviceInRedis != null && device == null) {
-				// redis 存在脏数据
-				redisCatchStorage.clearCatchByDeviceId(deviceId);
-			}
-			AuthorizationHeader authorhead = (AuthorizationHeader) request.getHeader(AuthorizationHeader.NAME);
-			// 校验密码是否正确
-			if (authorhead != null) {
-				passwordCorrect = new DigestServerAuthenticationHelper().doAuthenticatePlainTextPassword(request,
-						sipConfig.getPassword());
-			}
-			if (StringUtils.isEmpty(sipConfig.getPassword())){
-				passwordCorrect = true;
-			}
+            AuthorizationHeader authHead = (AuthorizationHeader) request.getHeader(AuthorizationHeader.NAME);
+            if (authHead == null) {
+                logger.info("[{}] 未携带授权头 回复401", requestAddress);
+                response = getMessageFactory().createResponse(Response.UNAUTHORIZED, request);
+                new DigestServerAuthenticationHelper().generateChallenge(getHeaderFactory(), response, sipConfig.getDomain());
+                sendResponse(evt, response);
+                return;
+            }
 
-			// 未携带授权头或者密码错误 回复401
-			if (authorhead == null ) {
+            // 校验密码是否正确
+            passwordCorrect = StringUtils.isEmpty(sipConfig.getPassword()) ||
+                    new DigestServerAuthenticationHelper().doAuthenticatePlainTextPassword(request, sipConfig.getPassword());
+            // 未携带授权头或者密码错误 回复401
 
-				logger.info("[{}] 未携带授权头 回复401", requestAddress);
-				response = getMessageFactory().createResponse(Response.UNAUTHORIZED, request);
-				new DigestServerAuthenticationHelper().generateChallenge(getHeaderFactory(), response, sipConfig.getDomain());
-			}else {
-				if (!passwordCorrect){
-					// 注册失败
-					response = getMessageFactory().createResponse(Response.FORBIDDEN, request);
-					response.setReasonPhrase("wrong password");
-					logger.info("[{}] 密码/SIP服务器ID错误, 回复403", requestAddress);
-				}else {
-					// 携带授权头并且密码正确
-					response = getMessageFactory().createResponse(Response.OK, request);
-					// 添加date头
-					SIPDateHeader dateHeader = new SIPDateHeader();
-					// 使用自己修改的
-					WvpSipDate wvpSipDate = new WvpSipDate(Calendar.getInstance(Locale.ENGLISH).getTimeInMillis());
-					dateHeader.setDate(wvpSipDate);
-					response.addHeader(dateHeader);
+            if (!passwordCorrect) {
+                // 注册失败
+                response = getMessageFactory().createResponse(Response.FORBIDDEN, request);
+                response.setReasonPhrase("wrong password");
+                logger.info("[{}] 密码/SIP服务器ID错误, 回复403", requestAddress);
+                sendResponse(evt, response);
+                return;
+            }
 
+            Device deviceInRedis = redisCatchStorage.getDevice(deviceId);
+            Device device = storager.queryVideoDevice(deviceId);
+            if (deviceInRedis != null && device == null) {
+                // redis 存在脏数据
+                redisCatchStorage.clearCatchByDeviceId(deviceId);
+            }
+            // 携带授权头并且密码正确
+            response = getMessageFactory().createResponse(Response.OK, request);
+            // 添加date头
+            SIPDateHeader dateHeader = new SIPDateHeader();
+            // 使用自己修改的
+            WvpSipDate wvpSipDate = new WvpSipDate(Calendar.getInstance(Locale.ENGLISH).getTimeInMillis());
+            dateHeader.setDate(wvpSipDate);
+            response.addHeader(dateHeader);
 
-					if (expiresHeader == null) {
-						response = getMessageFactory().createResponse(Response.BAD_REQUEST, request);
-						ServerTransaction serverTransaction = getServerTransaction(evt);
-						serverTransaction.sendResponse(response);
-						if (serverTransaction.getDialog() != null) serverTransaction.getDialog().delete();
-						return;
-					}
-					// 添加Contact头
-					response.addHeader(request.getHeader(ContactHeader.NAME));
-					// 添加Expires头
-					response.addHeader(request.getExpires());
+            if (expiresHeader == null) {
+                response = getMessageFactory().createResponse(Response.BAD_REQUEST, request);
+                ServerTransaction serverTransaction = getServerTransaction(evt);
+                serverTransaction.sendResponse(response);
+                if (serverTransaction.getDialog() != null) serverTransaction.getDialog().delete();
+                return;
+            }
+            // 添加Contact头
+            response.addHeader(request.getHeader(ContactHeader.NAME));
+            // 添加Expires头
+            response.addHeader(request.getExpires());
 
-					// 获取到通信地址等信息
-					ViaHeader viaHeader = (ViaHeader) request.getHeader(ViaHeader.NAME);
-					String received = viaHeader.getReceived();
-					int rPort = viaHeader.getRPort();
-					// 解析本地地址替代
-					if (StringUtils.isEmpty(received) || rPort == -1) {
-						received = viaHeader.getHost();
-						rPort = viaHeader.getPort();
-					}
-					//
+            // 获取到通信地址等信息
+            ViaHeader viaHeader = (ViaHeader) request.getHeader(ViaHeader.NAME);
+            String received = viaHeader.getReceived();
+            int rPort = viaHeader.getRPort();
+            // 解析本地地址替代
+            if (StringUtils.isEmpty(received) || rPort == -1) {
+                received = viaHeader.getHost();
+                rPort = viaHeader.getPort();
+            }
+            if (device == null) {
+                device = new Device();
+                device.setStreamMode("UDP");
+                device.setCharset("GB2312");
+                device.setDeviceId(deviceId);
+                device.setFirsRegister(true);
+            } else {
+                device.setFirsRegister(device.getOnline() == 0);
+            }
+            device.setIp(received);
+            device.setPort(rPort);
+            device.setHostAddress(received.concat(":").concat(String.valueOf(rPort)));
+            if (expiresHeader.getExpires() == 0) {
+                // 注销成功
+                registerFlag = 2;
+            } else {
+                // 注册成功
+                device.setExpires(expiresHeader.getExpires());
+                registerFlag = 1;
+                // 判断TCP还是UDP
+                ViaHeader reqViaHeader = (ViaHeader) request.getHeader(ViaHeader.NAME);
+                String transport = reqViaHeader.getTransport();
+                device.setTransport("TCP".equals(transport) ? "TCP" : "UDP");
+            }
 
-					if (device == null) {
-						device = new Device();
-						device.setStreamMode("UDP");
-						device.setCharset("GB2312");
-						device.setDeviceId(deviceId);
-						device.setFirsRegister(true);
-					}else {
-						if (device.getOnline() == 0) {
-							device.setFirsRegister(true);
-						}
-					}
-					device.setIp(received);
-					device.setPort(rPort);
-					device.setHostAddress(received.concat(":").concat(String.valueOf(rPort)));
-					// 注销成功
-					if (expiresHeader.getExpires() == 0) {
-						registerFlag = 2;
-					}
-					// 注册成功
-					else {
-						device.setExpires(expiresHeader.getExpires());
-						registerFlag = 1;
-						// 判断TCP还是UDP
-						boolean isTcp = false;
-						ViaHeader reqViaHeader = (ViaHeader) request.getHeader(ViaHeader.NAME);
-						String transport = reqViaHeader.getTransport();
-						if (transport.equals("TCP")) {
-							isTcp = true;
-						}
-						device.setTransport(isTcp ? "TCP" : "UDP");
-					}
-				}
-			}
+            sendResponse(evt, response);
+            // 注册成功
+            // 保存到redis
+            if (registerFlag == 1) {
+                logger.info("[{}] 注册成功! deviceId:" + deviceId, requestAddress);
+                publisher.onlineEventPublish(device, VideoManagerConstants.EVENT_ONLINE_REGISTER, expiresHeader.getExpires());
+            } else if (registerFlag == 2) {
+                logger.info("[{}] 注销成功! deviceId:" + deviceId, requestAddress);
+                publisher.outlineEventPublish(deviceId, VideoManagerConstants.EVENT_OUTLINE_UNREGISTER);
+            }
+        } catch (SipException | InvalidArgumentException | NoSuchAlgorithmException | ParseException e) {
+            e.printStackTrace();
+        }
 
-			ServerTransaction serverTransaction = getServerTransaction(evt);
-			serverTransaction.sendResponse(response);
-			if (serverTransaction.getDialog() != null) serverTransaction.getDialog().delete();
-			// 注册成功
-			// 保存到redis
-			if (registerFlag == 1 ) {
-				logger.info("[{}] 注册成功! deviceId:" + device.getDeviceId(), requestAddress);
-				publisher.onlineEventPublish(device, VideoManagerConstants.EVENT_ONLINE_REGISTER, expiresHeader.getExpires());
-			} else if (registerFlag == 2) {
-				logger.info("[{}] 注销成功! deviceId:" + device.getDeviceId(), requestAddress);
-				publisher.outlineEventPublish(device.getDeviceId(), VideoManagerConstants.EVENT_OUTLINE_UNREGISTER);
-			}
-		} catch (SipException | InvalidArgumentException | NoSuchAlgorithmException | ParseException e) {
-			e.printStackTrace();
-		}
-		
-	}
+    }
+
+    private void sendResponse(RequestEvent evt, Response response) throws InvalidArgumentException, SipException {
+        ServerTransaction serverTransaction = getServerTransaction(evt);
+        serverTransaction.sendResponse(response);
+        if (serverTransaction.getDialog() != null) serverTransaction.getDialog().delete();
+    }
 
 }


### PR DESCRIPTION
1.删除一个没有使用的引用private RegisterLogicHandler handler;
2.调整注册流程，提取了公共的返回方法，不再要求任意流程都走到最后一段才返回，节省4次IO：
   2.1首次请求无授权时，直接返回401，不再查询数据，不再查询redis，不再校验密码
   2.2携带授权头且密码错误时，直接返回403，不再查询数据，不再查询redis
3.若干if(xxx==true){xxx.set(true)}语法优化

其实只是简单的修改，不知道为什么git判断为整体删除更新，实测可以正常接入