### PR TITLE
Update VideoManagerStorageImpl.java

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/storager/impl/VideoManagerStorageImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/storager/impl/VideoManagerStorageImpl.java
@@ -314,9 +314,9 @@ public class VideoManagerStorageImpl implements IVideoManagerStorage {
 		PageHelper.startPage(page, count);
 		List<DeviceChannel> all;
 		if (catalogUnderDevice != null && catalogUnderDevice) {
-			all = deviceChannelMapper.queryChannels(deviceId, deviceId, query, hasSubChannel, online);
-		}else {
 			all = deviceChannelMapper.queryChannels(deviceId, null, query, hasSubChannel, online);
+		}else {
+			all = deviceChannelMapper.queryChannels(deviceId, deviceId, query, hasSubChannel, online);
 		}
 		return new PageInfo<>(all);
 	}


### PR DESCRIPTION
分页查询通道数，若直属于设备的目录，设备注册上报时parentId为sipId，不是deviceId，此处无法查询到合理结果；
若直属于设备的目录，设备/子目录（hasSubChannel）应为false或者为null，parentChannelId应为null而不是deviceId。
