### PR TITLE
fix(SIP): 修复海康NVR无parentId导致分屏监控没办法展开的问题

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/utils/XmlUtil.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/utils/XmlUtil.java
@@ -255,6 +255,8 @@ public class XmlUtil {
             }else if (deviceChannel.getChannelId().length() == 20) {
                 if (Integer.parseInt(deviceChannel.getChannelId().substring(10, 13)) == 216) { // 虚拟组织
                     deviceChannel.setParentId(businessGroupID);
+                }else if (Integer.parseInt(device.getDeviceId().substring(10, 13) )== 118) {//NVR 如果上级设备编号是NVR则直接将NVR的编号设置给通道的上级编号
+                    deviceChannel.setParentId(device.getDeviceId());
                 }else if (deviceChannel.getCivilCode() != null) {
                     // 设备， 无parentId的20位是使用CivilCode表示上级的设备，
                     // 注：215 业务分组是需要有parentId的


### PR DESCRIPTION
由于海康NVR通道信息中不带NVR的ID作为parentId。导致通道信息parentId缺失,
在通道信息中判断device信息中的DeviceId如果为NVR的话，将NVR的deviceId设置为通道的parentId