### PR TITLE
修改云端录像选择节点流媒体path不修改的bug

### DIFF
--- a/sql/mysql.sql
+++ b/sql/mysql.sql
@@ -48,6 +48,7 @@ CREATE TABLE `device` (
                           `ssrcCheck` int DEFAULT '0',
                           `geoCoordSys` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
                           `treeType` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                          `mediaServerId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT 'auto',
                           `custom_name` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
                           `password` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
                           PRIMARY KEY (`id`),

--- a/web_src/src/components/CloudRecord.vue
+++ b/web_src/src/components/CloudRecord.vue
@@ -109,14 +109,25 @@
           that.mediaServerList = data.data;
           if (that.mediaServerList.length > 0) {
             that.mediaServerId = that.mediaServerList[0].id
-            let port = that.mediaServerList[0].httpPort;
-            if (location.protocol === "https:" && that.mediaServerList[0].httpSSlPort) {
-              port = that.mediaServerList[0].httpSSlPort
-            }
-            that.mediaServerPath = location.protocol + "//" + that.mediaServerList[0].streamIp + ":" + port
+            that.setMediaServerPath(that.mediaServerId);
             that.getRecordList();
           }
         })
+      },
+      setMediaServerPath: function (serverId) {
+        let that = this;
+        let i;
+        for (i = 0; i < that.mediaServerList.length; i++) {
+          if (serverId === that.mediaServerList[i].id) {
+            break;
+          }
+        }
+        let port = that.mediaServerList[i].httpPort;
+        if (location.protocol === "https:" && that.mediaServerList[i].httpSSlPort) {
+          port = that.mediaServerList[i].httpSSlPort
+        }
+        that.mediaServerPath = location.protocol + "//" + that.mediaServerList[i].streamIp + ":" + port
+        console.log(that.mediaServerPath)
       },
       getRecordList: function (){
         let that = this;
@@ -146,6 +157,7 @@
           console.log(val)
           this.total = 0;
           this.recordList = [];
+          this.setMediaServerPath(val);
           this.getRecordList();
       },
       showRecordDetail(row){


### PR DESCRIPTION
修改云端录像选择节点流媒体path不修改的bug
代码中只取第一个节点的path，导致选择第二节点中的录像无法播放

device表增加的mediaServerId字段丢失，重新添加