### PR TITLE
修复视频播放页地址显示错误与截图模糊问题

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/service/impl/PlayServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/impl/PlayServiceImpl.java
@@ -271,7 +271,7 @@ public class PlayServiceImpl implements IPlayService {
                 onPublishHandlerForPlay(mediaServerItemInuse, response, device.getDeviceId(), channelId);
                 hookEvent.response(mediaServerItemInuse, response);
                 logger.info("[点播成功] deviceId: {}, channelId: {}", device.getDeviceId(), channelId);
-                String streamUrl = String.format("rtsp://127.0.0.1:%s/%s/%s", mediaServerItemInuse.getRtspPort(), "rtp",  ssrcInfo.getStream());
+                String streamUrl = String.format("http://127.0.0.1:%s/%s/%s.live.flv", mediaServerItemInuse.getHttpPort(), "rtp",  ssrcInfo.getStream());
                 String path = "snap";
                 String fileName = device.getDeviceId() + "_" + channelId + ".jpg";
                 // 请求截图

--- a/web_src/src/components/dialog/devicePlayer.vue
+++ b/web_src/src/components/dialog/devicePlayer.vue
@@ -123,7 +123,7 @@
                                 </el-dropdown-item>
                                 <el-dropdown-item v-if="streamInfo.rtcs" :command="streamInfo.rtcs.url">
                                   <el-tag >RTCS:</el-tag>
-                                  <span>{{ streamInfo.rtcs }}</span>
+                                  <span>{{ streamInfo.rtcs.url }}</span>
                                 </el-dropdown-item>
                                 <el-dropdown-item v-if="streamInfo.rtmp" :command="streamInfo.rtmp.url">
                                   <el-tag >RTMP:</el-tag>


### PR DESCRIPTION
1. 修复视频播放页面 RTCS 地址显示错误的问题；
2. 优化视频点播成功后截图使用 FLV 地址，解决 RTSP 地址截图后的图像丢包模糊的问题；