### PR TITLE
优化WVP作为下级平台查询设备录像列表上报缓慢问题

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/common/VideoManagerConstants.java
+++ b/src/main/java/com/genersoft/iot/vmp/common/VideoManagerConstants.java
@@ -138,4 +138,15 @@ public class VideoManagerConstants {
 	public static final String WVP_STREAM_GB_ID_PREFIX = "memberNo_";
 	public static final String WVP_STREAM_GPS_MSG_PREFIX = "WVP_STREAM_GPS_MSG_";
 
+	/**
+	 * Redis Const
+	 * 设备录像信息结果前缀
+	 */
+	public static final String REDIS_RECORD_INFO_RES_PRE = "GB_RECORD_INFO_RES_";
+	/**
+	 * Redis Const
+	 * 设备录像信息结果前缀
+	 */
+	public static final String REDIS_RECORD_INFO_RES_COUNT_PRE = "GB_RECORD_INFO_RES_COUNT:";
+
 }

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/response/impl/InviteResponseProcessor.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/response/impl/InviteResponseProcessor.java
@@ -80,8 +80,8 @@ public class InviteResponseProcessor extends SIPResponseProcessorAbstract {
 	 */
 	@Override
 	public void process(ResponseEvent evt ){
+		logger.debug("接收到消息：" + evt.getResponse());
 		try {
-
 			SIPResponse response = (SIPResponse)evt.getResponse();
 			int statusCode = response.getStatusCode();
 			// trying不会回复

--- a/src/main/java/com/genersoft/iot/vmp/utils/UJson.java
+++ b/src/main/java/com/genersoft/iot/vmp/utils/UJson.java
@@ -1,0 +1,150 @@
+package com.genersoft.iot.vmp.utils;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author gaofuwang
+ * @version 1.0
+ * @date 2022/3/11 10:17
+ */
+public class UJson {
+
+    private static Logger logger = LoggerFactory.getLogger(UJson.class);
+    public static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    static {
+        JSON_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,false);
+    }
+
+    private ObjectNode node;
+
+    public UJson(){
+        this.node = JSON_MAPPER.createObjectNode();
+    }
+
+    public UJson(String json){
+        if(StringUtils.isBlank(json)){
+            this.node = JSON_MAPPER.createObjectNode();
+        }else{
+            try {
+                this.node = JSON_MAPPER.readValue(json, ObjectNode.class);
+            }catch (Exception e){
+                logger.error(e.getMessage(), e);
+                this.node = JSON_MAPPER.createObjectNode();
+            }
+        }
+    }
+
+    public UJson(ObjectNode node){
+        this.node = node;
+    }
+
+    public String asText(String key){
+        JsonNode jsonNode = node.get(key);
+        if(Objects.isNull(jsonNode)){
+            return "";
+        }
+        return jsonNode.asText();
+    }
+
+    public String asText(String key, String defaultVal){
+        JsonNode jsonNode = node.get(key);
+        if(Objects.isNull(jsonNode)){
+            return "";
+        }
+        return jsonNode.asText(defaultVal);
+    }
+
+    public UJson put(String key, String value){
+        this.node.put(key, value);
+        return this;
+    }
+
+    public UJson put(String key, Integer value){
+        this.node.put(key, value);
+        return this;
+    }
+
+    public static UJson json(){
+        return new UJson();
+    }
+
+    public static UJson json(String json){
+        return new UJson(json);
+    }
+
+    public static <T> T readJson(String json, Class<T> clazz){
+        if(StringUtils.isBlank(json)){
+            return null;
+        }
+        try {
+            return JSON_MAPPER.readValue(json, clazz);
+        }catch (Exception e){
+            logger.error(e.getMessage(), e);
+            return null;
+        }
+    }
+
+    public static String writeJson(Object object) {
+        try{
+            return JSON_MAPPER.writeValueAsString(object);
+        }catch (Exception e){
+            logger.error(e.getMessage(), e);
+            return "";
+        }
+    }
+
+    @Override
+    public String toString() {
+        return node.toString();
+    }
+
+    public int asInt(String key, int defValue) {
+        JsonNode jsonNode = this.node.get(key);
+        if(Objects.isNull(jsonNode)){
+            return defValue;
+        }
+        return jsonNode.asInt(defValue);
+    }
+
+    public UJson getSon(String key) {
+        JsonNode sonNode = this.node.get(key);
+        if(Objects.isNull(sonNode)){
+            return new UJson();
+        }
+        return new UJson((ObjectNode) sonNode);
+    }
+
+    public UJson set(String key, ObjectNode sonNode) {
+        this.node.set(key, sonNode);
+        return this;
+    }
+
+    public UJson set(String key, UJson sonNode) {
+        this.node.set(key, sonNode.node);
+        return this;
+    }
+
+    public Iterator<Map.Entry<String, JsonNode>> fields() {
+        return this.node.fields();
+    }
+
+    public ObjectNode getNode() {
+        return this.node;
+    }
+
+    public UJson setAll(UJson json) {
+        this.node.setAll(json.node);
+        return this;
+    }
+}

--- a/src/main/java/com/genersoft/iot/vmp/utils/redis/RedisUtil.java
+++ b/src/main/java/com/genersoft/iot/vmp/utils/redis/RedisUtil.java
@@ -238,7 +238,7 @@ public class RedisUtil {
      * @param time 时间
      * @return true / false
      */
-    public static boolean hmset(String key, Map<Object, Object> map, long time) {
+    public static boolean hmset(String key, Map<?, ?> map, long time) {
         if (redisTemplate == null) {
             redisTemplate = SpringBeanFactory.getBean("redisTemplate");
         }


### PR DESCRIPTION
[优化WVP作为下级平台查询设备录像列表上报缓慢问题]:录像列表原有处理逻辑为单线程逻辑，效率并不是很高，现将缓存数据放入redis，多线程处理。提高处理效率；