### PR TITLE
RTP推流地址应使用SDP中Connection中的IP地址

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/InviteRequestProcessor.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/InviteRequestProcessor.java
@@ -314,7 +314,7 @@ public class InviteRequestProcessor extends SIPRequestProcessorParent implements
                     return;
                 }
                 String username = sdp.getOrigin().getUsername();
-                String addressStr = sdp.getOrigin().getAddress();
+                String addressStr = sdp.getConnection().getAddress();
 
                 logger.info("[上级点播]用户：{}， 通道：{}, 地址：{}:{}， ssrc：{}", username, channelId, addressStr, port, ssrc);
                 Device device = null;
@@ -912,7 +912,7 @@ public class InviteRequestProcessor extends SIPRequestProcessorParent implements
                     return;
                 }
                 String username = sdp.getOrigin().getUsername();
-                String addressStr = sdp.getOrigin().getAddress();
+                String addressStr = sdp.getConnection().getAddress();
                 logger.info("设备{}请求语音流，地址：{}:{}，ssrc：{}", username, addressStr, port, ssrc);
             } catch (SdpException e) {
                 logger.error("[SDP解析异常]", e);


### PR DESCRIPTION
RTP推流地址应使用SDP中Connection中的IP地址，原来使用Origin中的IP地址，在流媒体服务和信令服务不在同一台设备上时，媒体流数据将发给信令服务器，导致无法播放BUG。