### PR TITLE
fix: 根据国标设备编号查询设备没有返回通道数

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/storager/dao/DeviceMapper.java
+++ b/src/main/java/com/genersoft/iot/vmp/storager/dao/DeviceMapper.java
@@ -42,7 +42,8 @@ public interface DeviceMapper {
             "asMessageChannel," +
             "geoCoordSys," +
             "treeType," +
-            "online" +
+            "online," +
+            "(SELECT count(0) FROM device_channel WHERE deviceId=device.deviceId) as channelCount "+
             " FROM device WHERE deviceId = #{deviceId}")
     Device getDeviceByDeviceId(String deviceId);
 


### PR DESCRIPTION
在调用使用ID查询国标设备的接口 `/api/device/query/devices/{deviceId}` 发现返回结果中 `channelCount` 字段始终为0.