### PR TITLE
修复 RTSP 端口为空时使用 MP4 协议截图失败的问题

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/service/impl/MediaServerServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/impl/MediaServerServiceImpl.java
@@ -547,7 +547,9 @@ public class MediaServerServiceImpl implements IMediaServerService {
 
         Map<String, Object> param = new HashMap<>();
         param.put("api.secret",mediaServerItem.getSecret()); // -profile:v Baseline
-        param.put("ffmpeg.snap", "%s -rtsp_transport tcp -i %s -y -f mjpeg -t 0.001 %s");
+        if (mediaServerItem.getRtspPort() != 0) {
+            param.put("ffmpeg.snap", "%s -rtsp_transport tcp -i %s -y -f mjpeg -t 0.001 %s");
+        }
         param.put("hook.enable","1");
         param.put("hook.on_flow_report","");
         param.put("hook.on_play",String.format("%s/on_play", hookPrex));


### PR DESCRIPTION
修复 RTSP 端口为空时使用 MP4 协议截图失败的问题，判断是否通过 RTSP 协议截图，如果是则为 ZLM FFmpeg 截图添加 `-rtsp_transport tcp` 参数，否则不做处理。