### PR TITLE
优先使用SIP认证用户名

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/cmd/SIPRequestHeaderPlarformProvider.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/cmd/SIPRequestHeaderPlarformProvider.java
@@ -94,7 +94,13 @@ public class SIPRequestHeaderPlarformProvider {
 		SipURI requestURI = sipLayer.getSipFactory().createAddressFactory().createSipURI(parentPlatform.getServerGBId(), parentPlatform.getServerIP() + ":" + parentPlatform.getServerPort());
 		if (www == null) {
 			AuthorizationHeader authorizationHeader = sipLayer.getSipFactory().createHeaderFactory().createAuthorizationHeader("Digest");
-			authorizationHeader.setUsername(parentPlatform.getDeviceGBId());
+			String username = parentPlatform.getUsername();
+			if ( username == null || username == "" )
+			{
+				authorizationHeader.setUsername(parentPlatform.getDeviceGBId());
+			} else {
+				authorizationHeader.setUsername(username);
+			}
 			authorizationHeader.setURI(requestURI);
 			authorizationHeader.setAlgorithm("MD5");
 			registerRequest.addHeader(authorizationHeader);


### PR DESCRIPTION
加了一个if语句，不是java程序员，没有编译环境，没有编译更没有测试。
但是界面上配置SIP认证用户名抓包看到确实没有使用到Digest认证中，我认为是个问题。
可以拒绝这个PR，但这个问题建议处理一下。
