### PR TITLE
处理上级平台发送的invite请求不携带“y=”sdp信息时，并且设备已经在当前平台中点播了。给上级平台回复的ssrc使用默认“y=000…

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/InviteRequestProcessor.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/InviteRequestProcessor.java
@@ -482,6 +482,12 @@ public class InviteRequestProcessor extends SIPRequestProcessorParent implements
                                 redisCatchStorage.deleteSendRTPServer(platform.getServerGBId(), channelId, callIdHeader.getCallId(), null);
                             });
                         } else {
+                            // 当前系统作为下级平台使用，当上级平台点播时不携带ssrc时，并且设备在当前系统中已经点播了。这个时候需要重新给生成一个ssrc，不使用默认的"0000000000"。
+                            if (ssrc.equals(ssrcDefault)) {
+                                ssrc = ssrcFactory.getPlaySsrc(mediaServerItem.getId());
+                                sendRtpItem.setSsrc(ssrc);
+                            }
+
                             sendRtpItem.setStreamId(playTransaction.getStream());
                             // 写入redis， 超时时回复
                             redisCatchStorage.updateSendRTPSever(sendRtpItem);


### PR DESCRIPTION
处理上级平台发送的invite请求不携带“y=”sdp信息时，并且设备已经在当前平台中点播了。给上级平台回复的ssrc使用默认“y=0000000000”，上级平台无法播放视频的问题