### PR TITLE
修复 pr #817 ssrc的释放时机（当上级平台是单端口收流时，ssrc不能立马释放，因为ssrc有可能会重复使用，导致推流失败。）

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/ByeRequestProcessor.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/ByeRequestProcessor.java
@@ -101,6 +101,7 @@ public class ByeRequestProcessor extends SIPRequestProcessorParent implements In
 				param.put("ssrc",sendRtpItem.getSsrc());
 				logger.info("[收到bye] 停止向上级推流：{}", streamId);
 				MediaServerItem mediaInfo = mediaServerService.getOne(sendRtpItem.getMediaServerId());
+				mediaServerService.releaseSsrc(mediaInfo.getId(), sendRtpItem.getSsrc());
 				redisCatchStorage.deleteSendRTPServer(platformGbId, channelId, callIdHeader.getCallId(), null);
 				zlmrtpServerFactory.stopSendRtpStream(mediaInfo, param);
 				int totalReaderCount = zlmrtpServerFactory.totalReaderCount(mediaInfo, sendRtpItem.getApp(), streamId);

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/InviteRequestProcessor.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/InviteRequestProcessor.java
@@ -485,7 +485,6 @@ public class InviteRequestProcessor extends SIPRequestProcessorParent implements
                             // 当前系统作为下级平台使用，当上级平台点播时不携带ssrc时，并且设备在当前系统中已经点播了。这个时候需要重新给生成一个ssrc，不使用默认的"0000000000"。
                             if (ssrc.equals(ssrcDefault)) {
                                 ssrc = ssrcFactory.getPlaySsrc(mediaServerItem.getId());
-                                ssrcFactory.releaseSsrc(mediaServerItem.getId(), ssrc);
                                 sendRtpItem.setSsrc(ssrc);
                             }
 


### PR DESCRIPTION
修复 pr #817 ssrc的释放时机（当上级平台是单端口收流时，ssrc不能立马释放，因为ssrc有可能会重复使用，导致推流失败。）