### PR TITLE
fix `Notification is not defined` on some device

### DIFF
--- a/web_src/src/layout/UiHeader.vue
+++ b/web_src/src/layout/UiHeader.vue
@@ -40,6 +40,7 @@
 
 import changePasswordDialog from '../components/dialog/changePassword.vue'
 import userService from '../components/service/UserService'
+import {Notification} from 'element-ui';
 
 export default {
   name: "UiHeader",


### PR DESCRIPTION
fix #828 

如果没有这一行import,那么使用的会是Notification Web API,这在部分场景下是不支持的,具体见[Notification浏览器兼容性](https://developer.mozilla.org/zh-CN/docs/Web/API/Notification#%E6%B5%8F%E8%A7%88%E5%99%A8%E5%85%BC%E5%AE%B9%E6%80%A7) 比如在一些使用Android Webview的浏览器或部分ios系统上会导致报错而白屏
在此处应该为使用`element-ui`的Notification组件(下面有用到注册为element-ui的Notification全局属性$notify)