### PR TITLE
修复设备通道列表按通道类型筛选不准确等问题

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/service/impl/PlayServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/impl/PlayServiceImpl.java
@@ -271,18 +271,7 @@ public class PlayServiceImpl implements IPlayService {
                         streamInfo);
                 logger.info("[点播成功] deviceId: {}, channelId:{}, 码流类型：{}", device.getDeviceId(),
                         device.isSwitchPrimarySubStream() ? "辅码流" : "主码流");
-                String streamUrl;
-                if (mediaServerItemInuse.getRtspPort() != 0) {
-                    streamUrl = String.format("rtsp://127.0.0.1:%s/%s/%s", mediaServerItemInuse.getRtspPort(), "rtp",  ssrcInfo.getStream());
-                }else {
-                    streamUrl = String.format("http://127.0.0.1:%s/%s/%s.live.mp4", mediaServerItemInuse.getHttpPort(), "rtp",  ssrcInfo.getStream());
-                }
-                String path = "snap";
-                String fileName = device.getDeviceId() + "_" + channelId + ".jpg";
-                // 请求截图
-                logger.info("[请求截图]: " + fileName);
-                zlmresTfulUtils.getSnap(mediaServerItemInuse, streamUrl, 15, 1, path, fileName);
-
+                snapOnPlay(mediaServerItemInuse, device.getDeviceId(), channelId, ssrcInfo.getStream());
             }, (event) -> {
                 inviteInfo.setStatus(InviteSessionStatus.ok);
 
@@ -365,6 +354,7 @@ public class PlayServiceImpl implements IPlayService {
                                         InviteErrorCode.SUCCESS.getCode(),
                                         InviteErrorCode.SUCCESS.getMsg(),
                                         streamInfo);
+                                snapOnPlay(mediaServerItemInUse, device.getDeviceId(), channelId, stream);
                             });
                             return;
                         }
@@ -438,6 +428,28 @@ public class PlayServiceImpl implements IPlayService {
 
             inviteStreamService.removeInviteInfoByDeviceAndChannel(InviteSessionType.PLAY, device.getDeviceId(), channelId);
         }
+    }
+
+    /**
+     * 点播成功时调用截图.
+     *
+     * @param mediaServerItemInuse media
+     * @param deviceId             设备 ID
+     * @param channelId            通道 ID
+     * @param stream               ssrc
+     */
+    private void snapOnPlay(MediaServerItem mediaServerItemInuse, String deviceId, String channelId, String stream) {
+        String streamUrl;
+        if (mediaServerItemInuse.getRtspPort() != 0) {
+            streamUrl = String.format("rtsp://127.0.0.1:%s/%s/%s", mediaServerItemInuse.getRtspPort(), "rtp", stream);
+        } else {
+            streamUrl = String.format("http://127.0.0.1:%s/%s/%s.live.mp4", mediaServerItemInuse.getHttpPort(), "rtp", stream);
+        }
+        String path = "snap";
+        String fileName = deviceId + "_" + channelId + ".jpg";
+        // 请求截图
+        logger.info("[请求截图]: " + fileName);
+        zlmresTfulUtils.getSnap(mediaServerItemInuse, streamUrl, 15, 1, path, fileName);
     }
 
     private StreamInfo onPublishHandlerForPlay(MediaServerItem mediaServerItem, HookParam hookParam, String deviceId, String channelId) {


### PR DESCRIPTION
1. 解决设备通道按通道类型筛选不准确的问题，区分通道是否是设备应该按 parental 字段而不是 sub_count，因为部分子目录没有设备；
2. 修复作为上级平台点播无法截取快照的问题，下级平台自定义 ssrc 时，ssrc 修正后没有触发快照；