### PR TITLE
修复在国标级联选择通道时，如果添加通道到跟平台根目录（即平台本身），无法触发目录变更事件问题.详见 https://github.com/…

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/service/impl/PlatformChannelServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/impl/PlatformChannelServiceImpl.java
@@ -126,7 +126,15 @@ public class PlatformChannelServiceImpl implements IPlatformChannelService {
         List<DeviceChannel> deviceChannelList = new ArrayList<>();
         if (channelReduces.size() > 0){
             PlatformCatalog catalog = catalogManager.selectByPlatFormAndCatalogId(platform.getServerGBId(),catalogId);
-            if (catalog == null || !catalogId.equals(platform.getDeviceGBId())) {
+            if (catalog == null && catalogId.equals(platform.getDeviceGBId())) {
+                for (ChannelReduce channelReduce : channelReduces) {
+                    DeviceChannel deviceChannel = deviceChannelMapper.queryChannel(channelReduce.getDeviceId(), channelReduce.getChannelId());
+                    deviceChannel.setParental(0);
+                    deviceChannel.setCivilCode(platform.getServerGBDomain());
+                    deviceChannelList.add(deviceChannel);
+                }
+                return deviceChannelList;
+            } else if (catalog == null || !catalogId.equals(platform.getDeviceGBId())) {
                 logger.warn("未查询到目录{}的信息", catalogId);
                 return null;
             }


### PR DESCRIPTION
…648540858/wvp-GB28181-pro/issues/958