### PR TITLE
修复单端口推流下级自定义 ssrc 时, ssrc 修正不完全的问题

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/session/VideoStreamSessionManager.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/session/VideoStreamSessionManager.java
@@ -1,5 +1,6 @@
 package com.genersoft.iot.vmp.gb28181.session;
 
+import com.genersoft.iot.vmp.common.InviteInfo;
 import com.genersoft.iot.vmp.common.InviteSessionType;
 import com.genersoft.iot.vmp.common.VideoManagerConstants;
 import com.genersoft.iot.vmp.conf.UserSetting;
@@ -22,118 +23,150 @@ import java.util.List;
 @Component
 public class VideoStreamSessionManager {
 
-	@Autowired
-	private UserSetting userSetting;
+    @Autowired
+    private UserSetting userSetting;
 
-	@Autowired
-	private RedisTemplate<Object, Object> redisTemplate;
+    @Autowired
+    private RedisTemplate<Object, Object> redisTemplate;
 
-	/**
-	 * 添加一个点播/回放的事务信息
-	 * 后续可以通过流Id/callID
-	 * @param deviceId 设备ID
-	 * @param channelId 通道ID
-	 * @param callId 一次请求的CallID
-	 * @param stream 流名称
-	 * @param mediaServerId 所使用的流媒体ID
-	 * @param response 回复
-	 */
-	public void put(String deviceId, String channelId, String callId, String stream, String ssrc, String mediaServerId, SIPResponse response, InviteSessionType type){
-		SsrcTransaction ssrcTransaction = new SsrcTransaction();
-		ssrcTransaction.setDeviceId(deviceId);
-		ssrcTransaction.setChannelId(channelId);
-		ssrcTransaction.setStream(stream);
-		ssrcTransaction.setSipTransactionInfo(new SipTransactionInfo(response));
-		ssrcTransaction.setCallId(callId);
-		ssrcTransaction.setSsrc(ssrc);
-		ssrcTransaction.setMediaServerId(mediaServerId);
-		ssrcTransaction.setType(type);
+    /**
+     * 添加一个点播/回放的事务信息
+     * 后续可以通过流Id/callID
+     *
+     * @param deviceId      设备ID
+     * @param channelId     通道ID
+     * @param callId        一次请求的CallID
+     * @param stream        流名称
+     * @param mediaServerId 所使用的流媒体ID
+     * @param response      回复
+     */
+    public void put(String deviceId, String channelId, String callId, String stream, String ssrc, String mediaServerId, SIPResponse response, InviteSessionType type) {
+        SsrcTransaction ssrcTransaction = new SsrcTransaction();
+        ssrcTransaction.setDeviceId(deviceId);
+        ssrcTransaction.setChannelId(channelId);
+        ssrcTransaction.setStream(stream);
+        ssrcTransaction.setSipTransactionInfo(new SipTransactionInfo(response));
+        ssrcTransaction.setCallId(callId);
+        ssrcTransaction.setSsrc(ssrc);
+        ssrcTransaction.setMediaServerId(mediaServerId);
+        ssrcTransaction.setType(type);
 
-		redisTemplate.opsForValue().set(VideoManagerConstants.MEDIA_TRANSACTION_USED_PREFIX + userSetting.getServerId()
-				+ "_" +  deviceId + "_" + channelId + "_" + callId + "_" + stream, ssrcTransaction);
-	}
+        redisTemplate.opsForValue().set(VideoManagerConstants.MEDIA_TRANSACTION_USED_PREFIX + userSetting.getServerId()
+                + "_" + deviceId + "_" + channelId + "_" + callId + "_" + stream, ssrcTransaction);
+    }
 
-	public SsrcTransaction getSsrcTransaction(String deviceId, String channelId, String callId, String stream){
+    public SsrcTransaction getSsrcTransaction(String deviceId, String channelId, String callId, String stream) {
 
-		if (ObjectUtils.isEmpty(deviceId)) {
-			deviceId ="*";
-		}
-		if (ObjectUtils.isEmpty(channelId)) {
-			channelId ="*";
-		}
-		if (ObjectUtils.isEmpty(callId)) {
-			callId ="*";
-		}
-		if (ObjectUtils.isEmpty(stream)) {
-			stream ="*";
-		}
-		String key = VideoManagerConstants.MEDIA_TRANSACTION_USED_PREFIX + userSetting.getServerId() + "_" + deviceId + "_" + channelId + "_" + callId+ "_" + stream;
-		List<Object> scanResult = RedisUtil.scan(redisTemplate, key);
-		if (scanResult.size() == 0) {
-			return null;
-		}
-		return (SsrcTransaction)redisTemplate.opsForValue().get(scanResult.get(0));
-	}
+        if (ObjectUtils.isEmpty(deviceId)) {
+            deviceId = "*";
+        }
+        if (ObjectUtils.isEmpty(channelId)) {
+            channelId = "*";
+        }
+        if (ObjectUtils.isEmpty(callId)) {
+            callId = "*";
+        }
+        if (ObjectUtils.isEmpty(stream)) {
+            stream = "*";
+        }
+        String key = VideoManagerConstants.MEDIA_TRANSACTION_USED_PREFIX + userSetting.getServerId() + "_" + deviceId + "_" + channelId + "_" + callId + "_" + stream;
+        List<Object> scanResult = RedisUtil.scan(redisTemplate, key);
+        if (scanResult.size() == 0) {
+            return null;
+        }
+        return (SsrcTransaction) redisTemplate.opsForValue().get(scanResult.get(0));
+    }
 
-	public List<SsrcTransaction> getSsrcTransactionForAll(String deviceId, String channelId, String callId, String stream){
-		if (ObjectUtils.isEmpty(deviceId)) {
-			deviceId ="*";
-		}
-		if (ObjectUtils.isEmpty(channelId)) {
-			channelId ="*";
-		}
-		if (ObjectUtils.isEmpty(callId)) {
-			callId ="*";
-		}
-		if (ObjectUtils.isEmpty(stream)) {
-			stream ="*";
-		}
-		String key = VideoManagerConstants.MEDIA_TRANSACTION_USED_PREFIX + userSetting.getServerId() + "_" + deviceId + "_" + channelId + "_" + callId+ "_" + stream;
-		List<Object> scanResult = RedisUtil.scan(redisTemplate, key);
-		if (scanResult.size() == 0) {
-			return null;
-		}
-		List<SsrcTransaction> result = new ArrayList<>();
-		for (Object keyObj : scanResult) {
-			result.add((SsrcTransaction)redisTemplate.opsForValue().get(keyObj));
-		}
-		return result;
-	}
+    /**
+     * 更新缓存事务.
+     *
+     * @param inviteInfo 点播信息
+     * @param ssrc 下级平台自定义 ssrc
+     */
+    public void updateSsrcTransactionForStream(InviteInfo inviteInfo, String ssrc) {
+        String stream = String.format("%08x", Integer.parseInt(ssrc)).toUpperCase();
 
-	public String getMediaServerId(String deviceId, String channelId, String stream){
-		SsrcTransaction ssrcTransaction = getSsrcTransaction(deviceId, channelId, null, stream);
-		if (ssrcTransaction == null) {
-			return null;
-		}
-		return ssrcTransaction.getMediaServerId();
-	}
+        SsrcTransaction ssrcTransactionInDb = getSsrcTransaction(inviteInfo.getDeviceId(), inviteInfo.getChannelId(),
+                inviteInfo.getType().toString().toLowerCase(), inviteInfo.getStream());
+        if (ObjectUtils.isEmpty(ssrcTransactionInDb)) {
+            return;
+        }
 
-	public String getSSRC(String deviceId, String channelId, String stream){
-		SsrcTransaction ssrcTransaction = getSsrcTransaction(deviceId, channelId, null, stream);
-		if (ssrcTransaction == null) {
-			return null;
-		}
-		return ssrcTransaction.getSsrc();
-	}
-	
-	public void remove(String deviceId, String channelId, String stream) {
-		SsrcTransaction ssrcTransaction = getSsrcTransaction(deviceId, channelId, null, stream);
-		if (ssrcTransaction == null) {
-			return;
-		}
-		redisTemplate.delete(VideoManagerConstants.MEDIA_TRANSACTION_USED_PREFIX + userSetting.getServerId() + "_"
-				+  deviceId + "_" + channelId + "_" + ssrcTransaction.getCallId() + "_" + ssrcTransaction.getStream());
-	}
+        remove(ssrcTransactionInDb.getDeviceId(), ssrcTransactionInDb.getChannelId(),
+                ssrcTransactionInDb.getCallId(), ssrcTransactionInDb.getStream());
+        String key = VideoManagerConstants.MEDIA_TRANSACTION_USED_PREFIX
+                + userSetting.getServerId()
+                + "_" + ssrcTransactionInDb.getDeviceId()
+                + "_" + ssrcTransactionInDb.getChannelId()
+                + "_" + ssrcTransactionInDb.getCallId()
+                + "_" + stream;
+        ssrcTransactionInDb.setSsrc(ssrc);
+        ssrcTransactionInDb.setStream(stream);
+        redisTemplate.opsForValue().set(key, ssrcTransactionInDb);
+    }
 
+    public List<SsrcTransaction> getSsrcTransactionForAll(String deviceId, String channelId, String callId, String stream) {
+        if (ObjectUtils.isEmpty(deviceId)) {
+            deviceId = "*";
+        }
+        if (ObjectUtils.isEmpty(channelId)) {
+            channelId = "*";
+        }
+        if (ObjectUtils.isEmpty(callId)) {
+            callId = "*";
+        }
+        if (ObjectUtils.isEmpty(stream)) {
+            stream = "*";
+        }
+        String key = VideoManagerConstants.MEDIA_TRANSACTION_USED_PREFIX + userSetting.getServerId() + "_" + deviceId + "_" + channelId + "_" + callId + "_" + stream;
+        List<Object> scanResult = RedisUtil.scan(redisTemplate, key);
+        if (scanResult.size() == 0) {
+            return null;
+        }
+        List<SsrcTransaction> result = new ArrayList<>();
+        for (Object keyObj : scanResult) {
+            result.add((SsrcTransaction) redisTemplate.opsForValue().get(keyObj));
+        }
+        return result;
+    }
 
-	public List<SsrcTransaction> getAllSsrc() {
-		List<Object> ssrcTransactionKeys = RedisUtil.scan(redisTemplate, String.format("%s_*_*_*_*", VideoManagerConstants.MEDIA_TRANSACTION_USED_PREFIX+ userSetting.getServerId()));
-		List<SsrcTransaction> result= new ArrayList<>();
-		for (Object ssrcTransactionKey : ssrcTransactionKeys) {
-			String key = (String) ssrcTransactionKey;
-			SsrcTransaction ssrcTransaction = JsonUtil.redisJsonToObject(redisTemplate, key, SsrcTransaction.class);
-			result.add(ssrcTransaction);
-		}
-		return result;
-	}
+    public String getMediaServerId(String deviceId, String channelId, String stream) {
+        SsrcTransaction ssrcTransaction = getSsrcTransaction(deviceId, channelId, null, stream);
+        if (ssrcTransaction == null) {
+            return null;
+        }
+        return ssrcTransaction.getMediaServerId();
+    }
+
+    public String getSSRC(String deviceId, String channelId, String stream) {
+        SsrcTransaction ssrcTransaction = getSsrcTransaction(deviceId, channelId, null, stream);
+        if (ssrcTransaction == null) {
+            return null;
+        }
+        return ssrcTransaction.getSsrc();
+    }
+
+    public void remove(String deviceId, String channelId, String callId, String stream) {
+        SsrcTransaction ssrcTransaction = getSsrcTransaction(deviceId, channelId, callId, stream);
+        if (ssrcTransaction == null) {
+            return;
+        }
+        redisTemplate.delete(VideoManagerConstants.MEDIA_TRANSACTION_USED_PREFIX + userSetting.getServerId() + "_"
+                + deviceId + "_" + channelId + "_" + ssrcTransaction.getCallId() + "_" + ssrcTransaction.getStream());
+    }
+
+    public void remove(String deviceId, String channelId, String stream) {
+        remove(deviceId, channelId, null, stream);
+    }
+
+    public List<SsrcTransaction> getAllSsrc() {
+        List<Object> ssrcTransactionKeys = RedisUtil.scan(redisTemplate, String.format("%s_*_*_*_*", VideoManagerConstants.MEDIA_TRANSACTION_USED_PREFIX + userSetting.getServerId()));
+        List<SsrcTransaction> result = new ArrayList<>();
+        for (Object ssrcTransactionKey : ssrcTransactionKeys) {
+            String key = (String) ssrcTransactionKey;
+            SsrcTransaction ssrcTransaction = JsonUtil.redisJsonToObject(redisTemplate, key, SsrcTransaction.class);
+            result.add(ssrcTransaction);
+        }
+        return result;
+    }
 }

--- a/src/main/java/com/genersoft/iot/vmp/service/impl/PlayServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/impl/PlayServiceImpl.java
@@ -335,6 +335,11 @@ public class PlayServiceImpl implements IPlayService {
                             String stream = String.format("%08x", Integer.parseInt(ssrcInResponse)).toUpperCase();
                             hookSubscribe.getContent().put("stream", stream);
                             inviteStreamService.updateInviteInfoForStream(inviteInfo, stream);
+                            streamSession.updateSsrcTransactionForStream(inviteInfo, ssrcInResponse);
+                            ssrcInfo.setSsrc(ssrcInResponse);
+                            ssrcInfo.setStream(stream);
+                            inviteInfo.setSsrcInfo(ssrcInfo);
+                            inviteInfo.setStream(stream);
                             subscribe.addSubscribe(hookSubscribe, (mediaServerItemInUse, hookParam) -> {
                                 logger.info("[ZLM HOOK] ssrc修正后收到订阅消息： " + hookParam);
                                 dynamicTask.stop(timeOutTaskKey);


### PR DESCRIPTION
国标级联作为上级平台时，通过单端口推流，下级平台自定义 ssrc，ssrc 修正时未更新 redis 中缓存事务，会导致无法通过前端页面手动停止视频流