### PR TITLE
捕获启动过程中发送sip异常导致的启动失败

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/task/SipRunner.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/task/SipRunner.java
@@ -12,13 +12,19 @@ import com.genersoft.iot.vmp.media.zlm.dto.MediaServerItem;
 import com.genersoft.iot.vmp.service.IDeviceService;
 import com.genersoft.iot.vmp.service.IMediaServerService;
 import com.genersoft.iot.vmp.service.IPlatformService;
+import com.genersoft.iot.vmp.service.impl.PlatformServiceImpl;
 import com.genersoft.iot.vmp.storager.IRedisCatchStorage;
 import com.genersoft.iot.vmp.storager.IVideoManagerStorage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
+import javax.sip.InvalidArgumentException;
+import javax.sip.SipException;
+import java.text.ParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +64,8 @@ public class SipRunner implements CommandLineRunner {
 
     @Autowired
     private ISIPCommanderForPlatform commanderForPlatform;
+
+    private final static Logger logger = LoggerFactory.getLogger(PlatformServiceImpl.class);
 
     @Override
     public void run(String... args) throws Exception {
@@ -110,7 +118,11 @@ public class SipRunner implements CommandLineRunner {
                     if (jsonObject != null && jsonObject.getInteger("code") == 0) {
                         ParentPlatform platform = platformService.queryPlatformByServerGBId(sendRtpItem.getPlatformId());
                         if (platform != null) {
-                            commanderForPlatform.streamByeCmd(platform, sendRtpItem.getCallId());
+                            try {
+                                commanderForPlatform.streamByeCmd(platform, sendRtpItem.getCallId());
+                            } catch (InvalidArgumentException | ParseException | SipException e) {
+                                logger.error("[命令发送失败] 国标级联 发送BYE: {}", e.getMessage());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
例如上级平台离线，发送sip会失败从而导致wvp启动失败。