### PR TITLE
fix-use-source-ip-as-stream-ip

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/common/StreamInfo.java
+++ b/src/main/java/com/genersoft/iot/vmp/common/StreamInfo.java
@@ -523,6 +523,69 @@ public class StreamInfo implements Serializable, Cloneable{
         StreamInfo instance = null;
         try{
             instance = (StreamInfo)super.clone();
+            if (this.flv != null) {
+                instance.flv=this.flv.clone();
+            }
+            if (this.ws_flv != null ){
+                instance.ws_flv= this.ws_flv.clone();
+            }
+            if (this.hls != null ) {
+                instance.hls= this.hls.clone();
+            }
+            if (this.ws_hls != null ) {
+                instance.ws_hls= this.ws_hls.clone();
+            }
+            if (this.ts != null ) {
+                instance.ts= this.ts.clone();
+            }
+            if (this.ws_ts != null ) {
+                instance.ws_ts= this.ws_ts.clone();
+            }
+            if (this.fmp4 != null ) {
+                instance.fmp4= this.fmp4.clone();
+            }
+            if (this.ws_fmp4 != null ) {
+                instance.ws_fmp4= this.ws_fmp4.clone();
+            }
+            if (this.rtc != null ) {
+                instance.rtc= this.rtc.clone();
+            }
+            if (this.https_flv != null) {
+                instance.https_flv= this.https_flv.clone();
+            }
+            if (this.wss_flv != null) {
+                instance.wss_flv= this.wss_flv.clone();
+            }
+            if (this.https_hls != null) {
+                instance.https_hls= this.https_hls.clone();
+            }
+            if (this.wss_hls != null) {
+                instance.wss_hls= this.wss_hls.clone();
+            }
+            if (this.wss_ts != null) {
+                instance.wss_ts= this.wss_ts.clone();
+            }
+            if (this.https_fmp4 != null) {
+                instance.https_fmp4= this.https_fmp4.clone();
+            }
+            if (this.wss_fmp4 != null) {
+                instance.wss_fmp4= this.wss_fmp4.clone();
+            }
+            if (this.rtcs != null) {
+                instance.rtcs= this.rtcs.clone();
+            }
+            if (this.rtsp != null) {
+                instance.rtsp= this.rtsp.clone();
+            }
+            if (this.rtsps != null) {
+                instance.rtsps= this.rtsps.clone();
+            }
+            if (this.rtmp != null) {
+                instance.rtmp= this.rtmp.clone();
+            }
+            if (this.rtmps != null) {
+                instance.rtmps= this.rtmps.clone();
+            }
         }catch(CloneNotSupportedException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/genersoft/iot/vmp/common/StreamURL.java
+++ b/src/main/java/com/genersoft/iot/vmp/common/StreamURL.java
@@ -6,7 +6,7 @@ import java.io.Serializable;
 
 
 @Schema(description = "流地址信息")
-public class StreamURL implements Serializable {
+public class StreamURL implements Serializable,Cloneable {
 
     @Schema(description = "协议")
     private String protocol;
@@ -76,5 +76,9 @@ public class StreamURL implements Serializable {
         }else {
             return null;
         }
+    }
+    @Override
+    public StreamURL clone() throws CloneNotSupportedException {
+        return (StreamURL) super.clone();
     }
 }

--- a/src/main/java/com/genersoft/iot/vmp/vmanager/gb28181/play/PlayController.java
+++ b/src/main/java/com/genersoft/iot/vmp/vmanager/gb28181/play/PlayController.java
@@ -40,6 +40,8 @@ import org.springframework.web.context.request.async.DeferredResult;
 import javax.servlet.http.HttpServletRequest;
 import javax.sip.InvalidArgumentException;
 import javax.sip.SipException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.text.ParseException;
 import java.util.List;
 import java.util.UUID;
@@ -128,7 +130,15 @@ public class PlayController {
 				if (data != null) {
 					StreamInfo streamInfo = (StreamInfo)data;
 					if (userSetting.getUseSourceIpAsStreamIp()) {
-						streamInfo.channgeStreamIp(request.getLocalAddr());
+						streamInfo=streamInfo.clone();//深拷贝
+						String host;
+						try {
+							URL url=new URL(request.getRequestURL().toString());
+							host=url.getHost();
+						} catch (MalformedURLException e) {
+							host=request.getLocalAddr();
+						}
+						streamInfo.channgeStreamIp(host);
 					}
 					wvpResult.setData(new StreamContent(streamInfo));
 				}

--- a/src/main/java/com/genersoft/iot/vmp/vmanager/gb28181/playback/PlaybackController.java
+++ b/src/main/java/com/genersoft/iot/vmp/vmanager/gb28181/playback/PlaybackController.java
@@ -34,6 +34,8 @@ import org.springframework.web.context.request.async.DeferredResult;
 import javax.servlet.http.HttpServletRequest;
 import javax.sip.InvalidArgumentException;
 import javax.sip.SipException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.text.ParseException;
 import java.util.UUID;
 
@@ -99,7 +101,15 @@ public class PlaybackController {
 						if (data != null) {
 							StreamInfo streamInfo = (StreamInfo)data;
 							if (userSetting.getUseSourceIpAsStreamIp()) {
-								streamInfo.channgeStreamIp(request.getLocalAddr());
+								streamInfo=streamInfo.clone();//深拷贝
+								String host;
+								try {
+									URL url=new URL(request.getRequestURL().toString());
+									host=url.getHost();
+								} catch (MalformedURLException e) {
+									host=request.getLocalAddr();
+								}
+								streamInfo.channgeStreamIp(host);
 							}
 							wvpResult.setData(new StreamContent(streamInfo));
 						}


### PR DESCRIPTION
修复使用来源请求ip作为streamIp；
1、使用request.getRequestURL()，解决服务在NAT后面获取正确的映射地址，且同时支持内外网访问。
2、使用深拷贝，解决并发时有可能返回不正确的地址。