### PR TITLE
新增对录像辅助服务的ip配置支持

### DIFF
--- a/sql/2.6.9更新.sql
+++ b/sql/2.6.9更新.sql
@@ -1,8 +1,11 @@
 alter table wvp_device_channel
-    change stream_id stream_id varying(255)
+    change stream_id stream_id character varying(255)
 
 alter table wvp_platform
     add auto_push_channel bool default false
 
 alter table wvp_stream_proxy
-    add stream_key varying(255)
+    add stream_key character varying(255)
+
+alter table wvp_media_server
+    add record_assist_ip character varying(50)

--- a/sql/初始化.sql
+++ b/sql/初始化.sql
@@ -160,6 +160,7 @@ create table wvp_media_server (
                                   rtp_port_range character varying(50),
                                   send_rtp_port_range character varying(50),
                                   record_assist_port integer,
+                                  record_assist_ip character varying(50),
                                   default_server bool default false,
                                   create_time character varying(50),
                                   update_time character varying(50),

--- a/src/main/java/com/genersoft/iot/vmp/conf/MediaConfig.java
+++ b/src/main/java/com/genersoft/iot/vmp/conf/MediaConfig.java
@@ -81,6 +81,9 @@ public class MediaConfig{
     @Value("${media.record-assist-port:0}")
     private Integer recordAssistPort = 0;
 
+    @Value("${media.record-assist-ip:${media.ip}}")
+    private String recordAssistIp;
+
     public String getId() {
         return id;
     }
@@ -159,6 +162,10 @@ public class MediaConfig{
         return recordAssistPort;
     }
 
+    public String getRecordAssistIp() {
+        return recordAssistIp;
+    }
+
     public String getSdpIp() {
         if (ObjectUtils.isEmpty(sdpIp)){
             return ip;
@@ -211,6 +218,7 @@ public class MediaConfig{
         mediaServerItem.setRtpPortRange(rtpPortRange);
         mediaServerItem.setSendRtpPortRange(rtpSendPortRange);
         mediaServerItem.setRecordAssistPort(recordAssistPort);
+        mediaServerItem.setRecordAssistIp(recordAssistIp);
         mediaServerItem.setHookAliveInterval(30.00f);
 
         mediaServerItem.setCreateTime(DateUtil.getNow());

--- a/src/main/java/com/genersoft/iot/vmp/conf/ProxyServletConfig.java
+++ b/src/main/java/com/genersoft/iot/vmp/conf/ProxyServletConfig.java
@@ -242,8 +242,12 @@ public class ProxyServletConfig {
 
             String uri = null;
             if (mediaInfo != null) {
+                String ip = mediaInfo.getRecordAssistIp();
+                if (ip == null) {
+                    ip = mediaInfo.getIp();
+                }
 //                String realRequestURI = requestURI.substring(requestURI.indexOf(mediaInfo.getId())+ mediaInfo.getId().length());
-                uri = String.format("http://%s:%s", mediaInfo.getIp(), mediaInfo.getRecordAssistPort());
+                uri = String.format("http://%s:%s", ip, mediaInfo.getRecordAssistPort());
             }else {
                 uri = "http://127.0.0.1:" + serverPort +"/index/hook/null"; // 只是一个能返回404的请求而已， 其他的也可以
             }
@@ -259,7 +263,12 @@ public class ProxyServletConfig {
             MediaServerItem mediaInfo = getMediaInfoByUri(requestURI);
             HttpHost host;
             if (mediaInfo != null) {
-                host = new HttpHost(mediaInfo.getIp(), mediaInfo.getRecordAssistPort());
+                String ip = mediaInfo.getRecordAssistIp();
+                if (ip == null) {
+                    ip = mediaInfo.getIp();
+                }
+
+                host = new HttpHost(ip, mediaInfo.getRecordAssistPort());
             }else {
                 host = new HttpHost("127.0.0.1", serverPort);
             }

--- a/src/main/java/com/genersoft/iot/vmp/media/zlm/AssistRESTfulUtils.java
+++ b/src/main/java/com/genersoft/iot/vmp/media/zlm/AssistRESTfulUtils.java
@@ -51,7 +51,7 @@ public class AssistRESTfulUtils {
             return null;
         }
         StringBuffer stringBuffer = new StringBuffer();
-        stringBuffer.append(String.format("http://%s:%s/%s",  mediaServerItem.getIp(), mediaServerItem.getRecordAssistPort(), api));
+        stringBuffer.append(String.format("http://%s:%s/%s",  mediaServerItem.getRecordAssistIp(), mediaServerItem.getRecordAssistPort(), api));
         JSONObject responseJSON = null;
 
         if (param != null && param.keySet().size() > 0) {

--- a/src/main/java/com/genersoft/iot/vmp/media/zlm/ZLMHttpHookListener.java
+++ b/src/main/java/com/genersoft/iot/vmp/media/zlm/ZLMHttpHookListener.java
@@ -285,20 +285,26 @@ public class ZLMHttpHookListener {
                 result.setEnable_mp4(true);
             }
         }
-        if (mediaInfo.getRecordAssistPort() > 0 && userSetting.getRecordPath() == null) {
-            logger.info("推流时发现尚未设置录像路径，从assist服务中读取");
-            JSONObject info = assistRESTfulUtils.getInfo(mediaInfo, null);
-            if (info != null && info.getInteger("code") != null && info.getInteger("code") == 0 ) {
-                JSONObject dataJson = info.getJSONObject("data");
-                if (dataJson != null) {
-                    String recordPath = dataJson.getString("record");
-                    userSetting.setRecordPath(recordPath);
-                    result.setMp4_save_path(recordPath);
-                    // 修改zlm中的录像路径
-                    if (mediaInfo.isAutoConfig()) {
-                        taskExecutor.execute(() -> {
-                            mediaServerService.setZLMConfig(mediaInfo, false);
-                        });
+        if (mediaInfo.getRecordAssistPort() > 0) {
+            if (mediaInfo.getRecordAssistIp() == null) {
+                mediaInfo.setRecordAssistIp(mediaInfo.getIp());
+            }
+
+            if (userSetting.getRecordPath() == null) {
+                logger.info("推流时发现尚未设置录像路径，从assist服务中读取");
+                JSONObject info = assistRESTfulUtils.getInfo(mediaInfo, null);
+                if (info != null && info.getInteger("code") != null && info.getInteger("code") == 0 ) {
+                    JSONObject dataJson = info.getJSONObject("data");
+                    if (dataJson != null) {
+                        String recordPath = dataJson.getString("record");
+                        userSetting.setRecordPath(recordPath);
+                        result.setMp4_save_path(recordPath);
+                        // 修改zlm中的录像路径
+                        if (mediaInfo.isAutoConfig()) {
+                            taskExecutor.execute(() -> {
+                                mediaServerService.setZLMConfig(mediaInfo, false);
+                            });
+                        }
                     }
                 }
             }

--- a/src/main/java/com/genersoft/iot/vmp/media/zlm/dto/MediaServerItem.java
+++ b/src/main/java/com/genersoft/iot/vmp/media/zlm/dto/MediaServerItem.java
@@ -68,6 +68,9 @@ public class MediaServerItem{
     @Schema(description = "assist服务端口")
     private int recordAssistPort;
 
+    @Schema(description = "assist服务IP")
+    private String recordAssistIp;
+
     @Schema(description = "创建时间")
     private String createTime;
 
@@ -106,6 +109,7 @@ public class MediaServerItem{
         rtpEnable = false; // 默认使用单端口;直到用户自己设置开启多端口
         rtpPortRange = zlmServerConfig.getPortRange().replace("_",","); // 默认使用30000,30500作为级联时发送流的端口号
         recordAssistPort = 0; // 默认关闭
+        recordAssistIp = ip; // 默认使用media.ip
 
     }
 
@@ -243,6 +247,14 @@ public class MediaServerItem{
 
     public void setRecordAssistPort(int recordAssistPort) {
         this.recordAssistPort = recordAssistPort;
+    }
+
+    public String getRecordAssistIp() {
+        return recordAssistIp;
+    }
+
+    public void setRecordAssistIp(String recordAssistIp) {
+        this.recordAssistIp = recordAssistIp;
     }
 
     public boolean isDefaultServer() {

--- a/src/main/java/com/genersoft/iot/vmp/service/impl/MediaServerServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/impl/MediaServerServiceImpl.java
@@ -420,13 +420,19 @@ public class MediaServerServiceImpl implements IMediaServerService {
 
         if (serverItem.isAutoConfig()) {
             // 查看assist服务的录像路径配置
-            if (serverItem.getRecordAssistPort() > 0 && userSetting.getRecordPath() == null) {
-                JSONObject info = assistRESTfulUtils.getInfo(serverItem, null);
-                if (info != null && info.getInteger("code") != null && info.getInteger("code") == 0 ) {
-                    JSONObject dataJson = info.getJSONObject("data");
-                    if (dataJson != null) {
-                        String recordPath = dataJson.getString("record");
-                        userSetting.setRecordPath(recordPath);
+            if (serverItem.getRecordAssistPort() > 0) {
+                if (serverItem.getRecordAssistIp() == null) {
+                    serverItem.setRecordAssistIp(serverItem.getIp());
+                }
+
+                if (userSetting.getRecordPath() == null) {
+                    JSONObject info = assistRESTfulUtils.getInfo(serverItem, null);
+                    if (info != null && info.getInteger("code") != null && info.getInteger("code") == 0 ) {
+                        JSONObject dataJson = info.getJSONObject("data");
+                        if (dataJson != null) {
+                            String recordPath = dataJson.getString("record");
+                            userSetting.setRecordPath(recordPath);
+                        }
                     }
                 }
             }
@@ -588,7 +594,7 @@ public class MediaServerServiceImpl implements IMediaServerService {
         param.put("hook.on_send_rtp_stopped",String.format("%s/on_send_rtp_stopped", hookPrex));
         param.put("hook.on_rtp_server_timeout",String.format("%s/on_rtp_server_timeout", hookPrex));
         if (mediaServerItem.getRecordAssistPort() > 0) {
-            param.put("hook.on_record_mp4",String.format("http://127.0.0.1:%s/api/record/on_record_mp4", mediaServerItem.getRecordAssistPort()));
+            param.put("hook.on_record_mp4",String.format("http://%s:%s/api/record/on_record_mp4", mediaServerItem.getRecordAssistIp(), mediaServerItem.getRecordAssistPort()));
         }else {
             param.put("hook.on_record_mp4","");
         }
@@ -664,6 +670,7 @@ public class MediaServerServiceImpl implements IMediaServerService {
         mediaServerItem.setStreamIp(ip);
         mediaServerItem.setHookIp(sipConfig.getIp().split(",")[0]);
         mediaServerItem.setSdpIp(ip);
+        mediaServerItem.setRecordAssistIp(ip);
         return mediaServerItem;
     }
 

--- a/src/main/java/com/genersoft/iot/vmp/service/impl/PlayServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/impl/PlayServiceImpl.java
@@ -750,6 +750,10 @@ public class PlayServiceImpl implements IPlayService {
                 return null;
             }
             if (mediaServerItem.getRecordAssistPort() > 0) {
+                if (mediaServerItem.getRecordAssistIp() == null) {
+                    mediaServerItem.setRecordAssistIp(mediaServerItem.getIp());
+                }
+
                 JSONObject jsonObject = assistRESTfulUtils.fileDuration(mediaServerItem, inviteInfo.getStreamInfo().getApp(), inviteInfo.getStreamInfo().getStream(), null);
                 if (jsonObject == null) {
                     throw new ControllerException(ErrorCode.ERROR100.getCode(), "连接Assist服务失败");

--- a/src/main/java/com/genersoft/iot/vmp/storager/dao/MediaServerMapper.java
+++ b/src/main/java/com/genersoft/iot/vmp/storager/dao/MediaServerMapper.java
@@ -31,6 +31,7 @@ public interface MediaServerMapper {
             "rtp_port_range,"+
             "send_rtp_port_range,"+
             "record_assist_port,"+
+            "record_assist_ip,"+
             "default_server,"+
             "create_time,"+
             "update_time,"+
@@ -55,6 +56,7 @@ public interface MediaServerMapper {
             "#{rtpPortRange}, " +
             "#{sendRtpPortRange}, " +
             "#{recordAssistPort}, " +
+            "#{recordAssistIp}, " +
             "#{defaultServer}, " +
             "#{createTime}, " +
             "#{updateTime}, " +
@@ -81,6 +83,7 @@ public interface MediaServerMapper {
             "<if test=\"sendRtpPortRange != null\">, send_rtp_port_range=#{sendRtpPortRange}</if>" +
             "<if test=\"secret != null\">, secret=#{secret}</if>" +
             "<if test=\"recordAssistPort != null\">, record_assist_port=#{recordAssistPort}</if>" +
+            "<if test=\"recordAssistIp != null\">, record_assist_ip=#{recordAssistIp}</if>" +
             "<if test=\"hookAliveInterval != null\">, hook_alive_interval=#{hookAliveInterval}</if>" +
             "WHERE id=#{id}"+
             " </script>"})
@@ -105,6 +108,7 @@ public interface MediaServerMapper {
             "<if test=\"sendRtpPortRange != null\">, send_rtp_port_range=#{sendRtpPortRange}</if>" +
             "<if test=\"secret != null\">, secret=#{secret}</if>" +
             "<if test=\"recordAssistPort != null\">, record_assist_port=#{recordAssistPort}</if>" +
+            "<if test=\"recordAssistIp != null\">, record_assist_ip=#{recordAssistIp}</if>" +
             "<if test=\"hookAliveInterval != null\">, hook_alive_interval=#{hookAliveInterval}</if>" +
             "WHERE ip=#{ip} and http_port=#{httpPort}"+
             " </script>"})

--- a/src/main/resources/all-application.yml
+++ b/src/main/resources/all-application.yml
@@ -149,6 +149,8 @@ media:
         send-port-range: 50502,50506 # 端口范围
     # 录像辅助服务， 部署此服务可以实现zlm录像的管理与下载， 0 表示不使用
     record-assist-port: 0
+    # 录像辅助服务ip，置空使用media.ip
+    record-assist-ip:
 
 # [可选] 日志配置, 一般不需要改
 logging:

--- a/web_src/src/components/dialog/MediaServerEdit.vue
+++ b/web_src/src/components/dialog/MediaServerEdit.vue
@@ -95,6 +95,9 @@
                 -
                 <el-input v-model="sendRtpPortRange2" placeholder="终止" @change="portRangeChange" clearable style="width: 100px" prop="rtpPortRange2" :disabled="mediaServerForm.defaultServer"></el-input>
               </el-form-item>
+              <el-form-item label="录像管理服务IP" prop="ip">
+                <el-input v-model="mediaServerForm.recordAssistIp" placeholder="录像管理服务IP" clearable :disabled="mediaServerForm.defaultServer"></el-input>
+              </el-form-item>
               <el-form-item label="录像管理服务端口" prop="recordAssistPort">
                 <el-input v-model.number="mediaServerForm.recordAssistPort" :disabled="mediaServerForm.defaultServer">
 <!--                  <el-button v-if="mediaServerForm.recordAssistPort > 0" slot="append" type="primary" @click="checkRecordServer">测试</el-button>-->
@@ -174,6 +177,7 @@ export default {
         httpPort: "",
         httpSSlPort: "",
         recordAssistPort: "",
+        recordAssistIp: "",
         rtmpPort: "",
         rtmpSSlPort: "",
         rtpEnable: false,
@@ -334,6 +338,7 @@ export default {
         httpPort: "",
         httpSSlPort: "",
         recordAssistPort: "",
+        recordAssistIp: "",
         rtmpPort: "",
         rtmpSSlPort: "",
         rtpEnable: false,


### PR DESCRIPTION
主要针对开启录像辅助服务时，无法单独设置录像辅助服务的hook ip而出现的一些问题

1、新增对录像辅助服务的ip配置支持
2、修正sql更新脚本中错误的语句