### PR TITLE
fix(play): 修复单端口推流下级自定义 ssrc 时, 流注册后接口仍然超时的问题

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/service/impl/InviteStreamServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/impl/InviteStreamServiceImpl.java
@@ -257,7 +257,7 @@ public class InviteStreamServiceImpl implements IInviteStreamService {
                 ":" + inviteInfo.getDeviceId() +
                 ":" + inviteInfo.getChannelId() +
                 ":" + inviteInfo.getStream() +
-                ":" + inviteInfo.getSsrcInfo().getSsrc();
+                ":" + ssrc;
         if (inviteInfoInDb.getSsrcInfo() != null) {
             inviteInfoInDb.getSsrcInfo().setSsrc(ssrc);
         }


### PR DESCRIPTION
国标级联，单端口推流，下级自定义 ssrc 时，流注册成功后，接口并未返回仍然超时