### PR TITLE
bugfix：设备地址变化会引起目录订阅任务失效，需要重新添加

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/message/notify/cmd/KeepaliveNotifyMessageHandler.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/message/notify/cmd/KeepaliveNotifyMessageHandler.java
@@ -80,6 +80,11 @@ public class KeepaliveNotifyMessageHandler extends SIPRequestProcessorParent imp
             device.setPort(remoteAddressInfo.getPort());
             device.setHostAddress(remoteAddressInfo.getIp().concat(":").concat(String.valueOf(remoteAddressInfo.getPort())));
             device.setIp(remoteAddressInfo.getIp());
+            // 设备地址变化会引起目录订阅任务失效，需要重新添加
+            if (device.getSubscribeCycleForCatalog() > 0) {
+                deviceService.removeCatalogSubscribe(device);
+                deviceService.addCatalogSubscribe(device);
+            }
         }
         if (device.getKeepaliveTime() == null) {
             device.setKeepaliveIntervalTime(60);


### PR DESCRIPTION
问题验证：上级wvp平台重启后，创建目录订阅任务时的下级平台联系地址信息(hostAddress)是从数据库查询的，但此时下级平台的端口发生改变，导致目录订阅任务失效，出现以下报错：
![QH}77$PDI7R{C%EXL}`QTFG](https://github.com/648540858/wvp-GB28181-pro/assets/40308681/c3059596-2245-425d-9132-dba01b132073)
即使下级平台注册到期重新注册上线，由于目录订阅任务key重复，也无法重新添加。