### PR TITLE
修复OnStreamChangedHook媒体轨道信息解析错误

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/media/zlm/dto/hook/OnStreamChangedHookParam.java
+++ b/src/main/java/com/genersoft/iot/vmp/media/zlm/dto/hook/OnStreamChangedHookParam.java
@@ -120,17 +120,17 @@ public class OnStreamChangedHookParam extends HookParam{
         /**
          *  H264 = 0, H265 = 1, AAC = 2, G711A = 3, G711U = 4
          */
-        private int codecId;
+        private int codec_id;
 
         /**
          * 编码类型名称 CodecAAC CodecH264
          */
-        private String codecIdName;
+        private String codec_id_name;
 
         /**
          * Video = 0, Audio = 1
          */
-        private int codecType;
+        private int codec_type;
 
         /**
          * 轨道是否准备就绪
@@ -140,17 +140,17 @@ public class OnStreamChangedHookParam extends HookParam{
         /**
          * 音频采样位数
          */
-        private int sampleBit;
+        private int sample_bit;
 
         /**
          * 音频采样率
          */
-        private int sampleRate;
+        private int sample_rate;
 
         /**
          * 视频fps
          */
-        private int fps;
+        private float fps;
 
         /**
          * 视频高
@@ -162,6 +162,31 @@ public class OnStreamChangedHookParam extends HookParam{
          */
         private int width;
 
+        /**
+         * 帧数
+         */
+        private int frames;
+
+        /**
+         * 关键帧数
+         */
+        private int key_frames;
+
+        /**
+         * GOP大小
+         */
+        private int gop_size;
+
+        /**
+         * GOP间隔时长(ms)
+         */
+        private int gop_interval_ms;
+
+        /**
+         * 丢帧率
+         */
+        private float loss;
+
         public int getChannels() {
             return channels;
         }
@@ -170,28 +195,28 @@ public class OnStreamChangedHookParam extends HookParam{
             this.channels = channels;
         }
 
-        public int getCodecId() {
-            return codecId;
+        public int getCodec_id() {
+            return codec_id;
         }
 
-        public void setCodecId(int codecId) {
-            this.codecId = codecId;
+        public void setCodec_id(int codec_id) {
+            this.codec_id = codec_id;
         }
 
-        public String getCodecIdName() {
-            return codecIdName;
+        public String getCodec_id_name() {
+            return codec_id_name;
         }
 
-        public void setCodecIdName(String codecIdName) {
-            this.codecIdName = codecIdName;
+        public void setCodec_id_name(String codec_id_name) {
+            this.codec_id_name = codec_id_name;
         }
 
-        public int getCodecType() {
-            return codecType;
+        public int getCodec_type() {
+            return codec_type;
         }
 
-        public void setCodecType(int codecType) {
-            this.codecType = codecType;
+        public void setCodec_type(int codec_type) {
+            this.codec_type = codec_type;
         }
 
         public boolean isReady() {
@@ -202,27 +227,27 @@ public class OnStreamChangedHookParam extends HookParam{
             this.ready = ready;
         }
 
-        public int getSampleBit() {
-            return sampleBit;
+        public int getSample_bit() {
+            return sample_bit;
         }
 
-        public void setSampleBit(int sampleBit) {
-            this.sampleBit = sampleBit;
+        public void setSample_bit(int sample_bit) {
+            this.sample_bit = sample_bit;
         }
 
-        public int getSampleRate() {
-            return sampleRate;
+        public int getSample_rate() {
+            return sample_rate;
         }
 
-        public void setSampleRate(int sampleRate) {
-            this.sampleRate = sampleRate;
+        public void setSample_rate(int sample_rate) {
+            this.sample_rate = sample_rate;
         }
 
-        public int getFps() {
+        public float getFps() {
             return fps;
         }
 
-        public void setFps(int fps) {
+        public void setFps(float fps) {
             this.fps = fps;
         }
 
@@ -240,6 +265,46 @@ public class OnStreamChangedHookParam extends HookParam{
 
         public void setWidth(int width) {
             this.width = width;
+        }
+
+        public int getFrames() {
+            return frames;
+        }
+
+        public void setFrames(int frames) {
+            this.frames = frames;
+        }
+
+        public int getKey_frames() {
+            return key_frames;
+        }
+
+        public void setKey_frames(int key_frames) {
+            this.key_frames = key_frames;
+        }
+
+        public int getGop_size() {
+            return gop_size;
+        }
+
+        public void setGop_size(int gop_size) {
+            this.gop_size = gop_size;
+        }
+
+        public int getGop_interval_ms() {
+            return gop_interval_ms;
+        }
+
+        public void setGop_interval_ms(int gop_interval_ms) {
+            this.gop_interval_ms = gop_interval_ms;
+        }
+
+        public float getLoss() {
+            return loss;
+        }
+
+        public void setLoss(float loss) {
+            this.loss = loss;
         }
     }
 


### PR DESCRIPTION
媒体轨道信息与ZLM返回的不匹配，导致若干信息解析失败或丢失，予以修复。

ZLM返回的tracks信息如下：

```json
			"tracks": [
				{
					"channels": 1,
					"codec_id": 3,
					"codec_id_name": "PCMA",
					"codec_type": 1,
					"frames": 12693,
					"ready": true,
					"sample_bit": 16,
					"sample_rate": 8000
				},
				{
					"codec_id": 0,
					"codec_id_name": "H264",
					"codec_type": 0,
					"fps": 25.0,
					"frames": 12687,
					"gop_interval_ms": 1994,
					"gop_size": 50,
					"height": 576,
					"key_frames": 255,
					"ready": true,
					"width": 704
				}
			],
```