### PR TITLE
修改输出的日志格式

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/conf/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/genersoft/iot/vmp/conf/security/JwtAuthenticationFilter.java
@@ -78,6 +78,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 构建UsernamePasswordAuthenticationToken,这里密码为null，是因为提供了正确的JWT,实现自动登录
         User user = new User();
+        user.setId(jwtUser.getUserId());
         user.setUsername(jwtUser.getUserName());
         user.setPassword(jwtUser.getPassword());
         Role role = new Role();

--- a/src/main/java/com/genersoft/iot/vmp/conf/security/JwtUtils.java
+++ b/src/main/java/com/genersoft/iot/vmp/conf/security/JwtUtils.java
@@ -144,6 +144,7 @@ public class JwtUtils implements InitializingBean {
             jwtUser.setUserName(username);
             jwtUser.setPassword(user.getPassword());
             jwtUser.setRoleId(user.getRole().getId());
+            jwtUser.setUserId(user.getId());
 
             return jwtUser;
         } catch (InvalidJwtException e) {

--- a/src/main/java/com/genersoft/iot/vmp/conf/security/dto/JwtUser.java
+++ b/src/main/java/com/genersoft/iot/vmp/conf/security/dto/JwtUser.java
@@ -21,6 +21,7 @@ public class JwtUser {
         EXCEPTION
     }
 
+    private int userId;
     private String userName;
 
     private String password;
@@ -28,6 +29,14 @@ public class JwtUser {
     private int roleId;
 
     private TokenStatus status;
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
 
     public String getUserName() {
         return userName;

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/conf/StackLoggerImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/conf/StackLoggerImpl.java
@@ -1,8 +1,8 @@
 package com.genersoft.iot.vmp.gb28181.conf;
 
 import gov.nist.core.StackLogger;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.spi.LocationAwareLogger;
 import org.springframework.stereotype.Component;
 
 import java.util.Properties;
@@ -10,100 +10,132 @@ import java.util.Properties;
 @Component
 public class StackLoggerImpl implements StackLogger {
 
-    private final static Logger logger = LoggerFactory.getLogger(StackLoggerImpl.class);
+	/**
+	 * 完全限定类名(Fully Qualified Class Name)，用于定位日志位置
+	 */
+	private static final String FQCN = StackLoggerImpl.class.getName();
 
-    @Override
-    public void logStackTrace() {
+	/**
+	 * 获取栈中类信息(以便底层日志记录系统能够提取正确的位置信息(方法名、行号))
+	 * @return LocationAwareLogger
+	 */
+	private static LocationAwareLogger getLocationAwareLogger() {
+		return (LocationAwareLogger) LoggerFactory.getLogger(new Throwable().getStackTrace()[4].getClassName());
+	}
 
-    }
 
-    @Override
-    public void logStackTrace(int traceLevel) {
-        System.out.println("traceLevel: "  + traceLevel);
-    }
+	/**
+	 * 封装打印日志的位置信息
+	 * @param level   日志级别
+	 * @param message 日志事件的消息
+	 */
+	private static void log(int level, String message) {
+		LocationAwareLogger locationAwareLogger = getLocationAwareLogger();
+		locationAwareLogger.log(null, FQCN, level, message, null, null);
+	}
 
-    @Override
-    public int getLineCount() {
-        return 0;
-    }
+	/**
+	 * 封装打印日志的位置信息
+	 * @param level   日志级别
+	 * @param message 日志事件的消息
+	 */
+	private static void log(int level, String message, Throwable throwable) {
+		LocationAwareLogger locationAwareLogger = getLocationAwareLogger();
+		locationAwareLogger.log(null, FQCN, level, message, null, throwable);
+	}
 
-    @Override
-    public void logException(Throwable ex) {
+	@Override
+	public void logStackTrace() {
 
-    }
+	}
 
-    @Override
-    public void logDebug(String message) {
-//        logger.debug(message);
-    }
+	@Override
+	public void logStackTrace(int traceLevel) {
+		System.out.println("traceLevel: " + traceLevel);
+	}
 
-    @Override
-    public void logDebug(String message, Exception ex) {
-//        logger.debug(message);
-    }
+	@Override
+	public int getLineCount() {
+		return 0;
+	}
 
-    @Override
-    public void logTrace(String message) {
-        logger.trace(message);
-    }
+	@Override
+	public void logException(Throwable ex) {
 
-    @Override
-    public void logFatalError(String message) {
-//        logger.error(message);
-    }
+	}
 
-    @Override
-    public void logError(String message) {
-//        logger.error(message);
-    }
+	@Override
+	public void logDebug(String message) {
+		log(LocationAwareLogger.INFO_INT, message);
+	}
 
-    @Override
-    public boolean isLoggingEnabled() {
-        return true;
-    }
+	@Override
+	public void logDebug(String message, Exception ex) {
+		log(LocationAwareLogger.INFO_INT, message, ex);
+	}
 
-    @Override
-    public boolean isLoggingEnabled(int logLevel) {
-        return true;
-    }
+	@Override
+	public void logTrace(String message) {
+		log(LocationAwareLogger.INFO_INT, message);
+	}
 
-    @Override
-    public void logError(String message, Exception ex) {
-//        logger.error(message);
-    }
+	@Override
+	public void logFatalError(String message) {
+		log(LocationAwareLogger.INFO_INT, message);
+	}
 
-    @Override
-    public void logWarning(String message) {
-        logger.warn(message);
-    }
+	@Override
+	public void logError(String message) {
+		log(LocationAwareLogger.INFO_INT, message);
+	}
 
-    @Override
-    public void logInfo(String message) {
-        logger.info(message);
-    }
+	@Override
+	public boolean isLoggingEnabled() {
+		return true;
+	}
 
-    @Override
-    public void disableLogging() {
+	@Override
+	public boolean isLoggingEnabled(int logLevel) {
+		return true;
+	}
 
-    }
+	@Override
+	public void logError(String message, Exception ex) {
+		log(LocationAwareLogger.INFO_INT, message, ex);
+	}
 
-    @Override
-    public void enableLogging() {
+	@Override
+	public void logWarning(String message) {
+		log(LocationAwareLogger.INFO_INT, message);
+	}
 
-    }
+	@Override
+	public void logInfo(String message) {
+		log(LocationAwareLogger.INFO_INT, message);
+	}
 
-    @Override
-    public void setBuildTimeStamp(String buildTimeStamp) {
+	@Override
+	public void disableLogging() {
 
-    }
+	}
 
-    @Override
-    public void setStackProperties(Properties stackProperties) {
+	@Override
+	public void enableLogging() {
 
-    }
+	}
 
-    @Override
-    public String getLoggerName() {
-        return null;
-    }
+	@Override
+	public void setBuildTimeStamp(String buildTimeStamp) {
+
+	}
+
+	@Override
+	public void setStackProperties(Properties stackProperties) {
+
+	}
+
+	@Override
+	public String getLoggerName() {
+		return null;
+	}
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,8 +4,8 @@
 	<springProperty scop="context" name="spring.application.name" source="spring.application.name" defaultValue=""/>
 	<property name="LOG_HOME" value="logs" />
 
-	<substitutionProperty name="log.pattern" value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr(%-1.30logger{0}){cyan} %clr(:){faint} %m%n%wEx"/>
-
+	<substitutionProperty name="log.pattern"
+						  value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr([%thread]) %clr(%5p) %clr(---){faint} %clr(%logger{50}){cyan} %clr(:) %clr(%L){faint} %m%n%wEx"/>
 	<conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
 	<conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter"/>
 	<conversionRule conversionWord="wEx" converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter"/>


### PR DESCRIPTION
1、修改控制台输出日志格式，增加显示线程名称，调用类的全类路径以及日子输出行的行号；
2、增加日志记录时的完全限定类名，用于定位日志位置。
ps：2023-12-12 16:30:58.779 [Thread-10]  INFO --- gov.nist.javax.sip.stack.UDPMessageChannel : 81 Done processing MESSAGE sip:44010200492000000003@4401020049 SIP/2.0  日志中的“gov.nist.javax.sip.stack.UDPMessageChannel”内容。