### PR TITLE
修复未配置sipdomain时出现异常

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/session/SSRCFactory.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/session/SSRCFactory.java
@@ -38,7 +38,8 @@ public class SSRCFactory {
 
 
     public void initMediaServerSSRC(String mediaServerId, Set<String> usedSet) {
-        String ssrcPrefix = sipConfig.getDomain().substring(3, 8);
+        String sipDomain = sipConfig.getDomain();
+        String ssrcPrefix = sipDomain.length() >= 8 ? sipDomain.substring(3, 8) : sipDomain;
         String redisKey = SSRC_INFO_KEY + userSetting.getServerId() + "_" + mediaServerId;
         List<String> ssrcList = new ArrayList<>();
         for (int i = 1; i < MAX_STREAM_COUNT; i++) {


### PR DESCRIPTION
如果配置中未配置sip domain字段,则此处的代码会引发索引越界异常