### PR TITLE
Fix 推流列表-> 添加通道 报错： 错误: 字段 "gbStreamId" 不存在 ,改为：gb_stream_id 自测试通过

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/storager/dao/GbStreamMapper.java
+++ b/src/main/java/com/genersoft/iot/vmp/storager/dao/GbStreamMapper.java
@@ -20,7 +20,7 @@ public interface GbStreamMapper {
             "(#{app}, #{stream}, #{gbId}, #{name}, " +
             "#{longitude}, #{latitude}, #{streamType}, " +
             "#{mediaServerId}, #{createTime})")
-    @Options(useGeneratedKeys = true, keyProperty = "gbStreamId", keyColumn = "gbStreamId")
+    @Options(useGeneratedKeys = true, keyProperty = "gbStreamId", keyColumn = "gb_stream_id")
     int add(GbStream gbStream);
 
     @Update("UPDATE wvp_gb_stream " +


### PR DESCRIPTION
解决issue ：https://github.com/648540858/wvp-GB28181-pro/issues/1275