### PR TITLE
[bugfix]修复云端录像查询时间转换错误的问题

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/service/impl/CloudRecordServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/impl/CloudRecordServiceImpl.java
@@ -59,14 +59,14 @@ public class CloudRecordServiceImpl implements ICloudRecordService {
             if (!DateUtil.verification(startTime, DateUtil.formatter)) {
                 throw new ControllerException(ErrorCode.ERROR100.getCode(), "开始时间格式错误，正确格式为： " + DateUtil.formatter);
             }
-            startTimeStamp = DateUtil.yyyy_MM_dd_HH_mm_ssToTimestamp(startTime);
+            startTimeStamp = DateUtil.yyyy_MM_dd_HH_mm_ssToTimestampMs(startTime);
 
         }
         if (endTime != null ) {
             if (!DateUtil.verification(endTime, DateUtil.formatter)) {
                 throw new ControllerException(ErrorCode.ERROR100.getCode(), "结束时间格式错误，正确格式为： " + DateUtil.formatter);
             }
-            endTimeStamp = DateUtil.yyyy_MM_dd_HH_mm_ssToTimestamp(endTime);
+            endTimeStamp = DateUtil.yyyy_MM_dd_HH_mm_ssToTimestampMs(endTime);
 
         }
         PageHelper.startPage(page, count);

--- a/src/main/java/com/genersoft/iot/vmp/utils/DateUtil.java
+++ b/src/main/java/com/genersoft/iot/vmp/utils/DateUtil.java
@@ -107,6 +107,26 @@ public class DateUtil {
 	}
 
     /**
+     * yyyy_MM_dd_HH_mm_ss 转时间戳（毫秒）
+     *
+     * @param formatTime
+     * @return
+     */
+    public static long yyyy_MM_dd_HH_mm_ssToTimestampMs(String formatTime) {
+        TemporalAccessor temporalAccessor = formatter.parse(formatTime);
+        Instant instant = Instant.from(temporalAccessor);
+        return instant.toEpochMilli();
+    }
+
+    /**
+     * 时间戳（毫秒） 转 yyyy_MM_dd_HH_mm_ss
+     */
+    public static String timestampMsTo_yyyy_MM_dd_HH_mm_ss(long timestamp) {
+        Instant instant = Instant.ofEpochMilli(timestamp);
+        return formatter.format(LocalDateTime.ofInstant(instant, ZoneId.of(zoneStr)));
+    }
+
+    /**
      * 时间戳 转 yyyy_MM_dd
      */
     public static String timestampTo_yyyy_MM_dd(long timestamp) {


### PR DESCRIPTION
修复：云端录像查询时因为使用了秒级时间戳，而数据库存储的却毫秒级时间戳，导致无法查询出实际的录像记录