### PR TITLE
修复在docker中使用，平台信息IP无法显示主机IP的问题

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/SipLayer.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/SipLayer.java
@@ -82,7 +82,9 @@ public class SipLayer implements CommandLineRunner {
 				monitorIps.add(sipConfig.getIp());
 			}
 		}
-		sipConfig.setShowIp(String.join(",", monitorIps));
+		if (ObjectUtils.isEmpty(sipConfig.getShowIp())){
+			sipConfig.setShowIp(String.join(",", monitorIps));
+		}
 		SipFactory.getInstance().setPathName("gov.nist");
 		if (monitorIps.size() > 0) {
 			for (String monitorIp : monitorIps) {


### PR DESCRIPTION
配置sip,showip用来显示主机IP