### PR TITLE
 [bugfix]修复前面几次合并所遗漏的一些问题

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/storager/impl/RedisCatchStorageImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/storager/impl/RedisCatchStorageImpl.java
@@ -10,7 +10,6 @@ import com.genersoft.iot.vmp.media.bean.MediaInfo;
 import com.genersoft.iot.vmp.media.bean.MediaServer;
 import com.genersoft.iot.vmp.media.event.media.MediaArrivalEvent;
 import com.genersoft.iot.vmp.media.zlm.dto.StreamAuthorityInfo;
-import com.genersoft.iot.vmp.media.zlm.dto.StreamPushItem;
 import com.genersoft.iot.vmp.media.zlm.dto.hook.OnStreamChangedHookParam;
 import com.genersoft.iot.vmp.service.bean.GPSMsgInfo;
 import com.genersoft.iot.vmp.service.bean.MessageForPushChannel;
@@ -707,7 +706,7 @@ public class RedisCatchStorageImpl implements IRedisCatchStorage {
     @Override
     public void removePushListItem(String app, String stream, String mediaServerId) {
         String key = VideoManagerConstants.PUSH_STREAM_LIST + app + "_" + stream;
-        StreamPushItem param = (StreamPushItem)redisTemplate.opsForValue().get(key);
+        OnStreamChangedHookParam param = (OnStreamChangedHookParam)redisTemplate.opsForValue().get(key);
         if (param != null && param.getMediaServerId().equalsIgnoreCase(mediaServerId)) {
             redisTemplate.delete(key);
         }

--- a/src/main/java/com/genersoft/iot/vmp/storager/impl/RedisCatchStorageImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/storager/impl/RedisCatchStorageImpl.java
@@ -694,6 +694,7 @@ public class RedisCatchStorageImpl implements IRedisCatchStorage {
     @Override
     public void addPushListItem(String app, String stream, MediaArrivalEvent event) {
         String key = VideoManagerConstants.PUSH_STREAM_LIST + app + "_" + stream;
+        event.getHookParam().setSeverId(userSetting.getServerId());
         redisTemplate.opsForValue().set(key, event.getHookParam());
     }
 

--- a/web_src/src/components/console/ConsoleNet.vue
+++ b/web_src/src/components/console/ConsoleNet.vue
@@ -103,7 +103,7 @@ export default {
           bottom: "15px",
           selected: {},
         }
-      }
+      },
       chartEvents: {
         legendselectchanged: (item) => {
           this.extend.legend.selected = item.selected;


### PR DESCRIPTION
- [241e29f] 最近的一次合并，ConsoleNet.vue 漏了个逗号，导致无法编译前端 → [fix: #1558]。
- [87c071f] 6月25日合并271: 
  - 在处理断流事件时，变量类型未同步更新，导致事件处理异常；
  - 同步推流事件到redis时，漏了设置serverID，导致上级平台无法点播 → [fix: #1536]。