### PR TITLE
支持config.js中配置多层地图瓦片

### DIFF
--- a/web_src/src/components/common/MapComponent.vue
+++ b/web_src/src/components/common/MapComponent.vue
@@ -59,25 +59,28 @@ export default {
           maxZoom: mapParam.maxZoom || 19,
           minZoom: mapParam.minZoom || 1,
         });
-        let tileLayer = null;
+        let tileLayers = [];
         if (mapParam.tilesUrl) {
-          tileLayer = new Tile({
-            source: new XYZ({
-              projection: getProj("EPSG:3857"),
-              wrapX: false,
-              tileSize: 256 || mapParam.tileSize,
-              url: mapParam.tilesUrl
-            })
+          const tilesUrls = Array.isArray(mapParam.tilesUrl) ? mapParam.tilesUrl : [mapParam.tilesUrl]
+          tilesUrls.forEach(tilesUrl => {
+            tileLayers.push(new Tile({
+              source: new XYZ({
+                projection: getProj("EPSG:3857"),
+                wrapX: false,
+                tileSize: 256 || mapParam.tileSize,
+                url: tilesUrl
+              })
+            }))
           })
         }else {
-          tileLayer = new Tile({
-            preload: 4,
-            source: new OSM(),
-          })
+          tileLayers.push(new Tile({
+              preload: 4,
+              source: new OSM(),
+          }))
         }
         olMap = new Map({
           target: this.$refs.mapContainer, // 容器ID
-          layers:  [tileLayer], // 默认图层
+          layers: tileLayers, // 默认图层
           view: view,  // 视图
           controls:[   // 控件
             // new ZoomSlider(),

--- a/web_src/static/js/config.js
+++ b/web_src/static/js/config.js
@@ -8,6 +8,7 @@ window.mapParam = {
   // 坐标系 GCJ-02 WGS-84,
   coordinateSystem: "GCJ-02",
   // 地图瓦片地址
+  // 地图瓦片地址 , 支持string[]类型作为多层地图瓦片
   tilesUrl: "http://webrd0{1-4}.is.autonavi.com/appmaptile?x={x}&y={y}&z={z}&lang=zh_cn&size=1&scale=1&style=8",
   // 瓦片大小
   tileSize: 256,


### PR DESCRIPTION
支持解析mapParam中tilesUrl类型为string[]
例如
```javascript
window.mapParam = {
  // ...
  // 地图瓦片地址 , 支持string[]类型作为多层地图瓦片
  tilesUrl: ["http://webrd0{1-4}.is.autonavi.com/appmaptile?x={x}&y={y}&z={z}&lang=zh_cn&size=1&scale=1&style=8"],
  // ...
}
```