### PR TITLE
修复设备通道SQL查询中的字段名错误

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/dao/DeviceChannelMapper.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/dao/DeviceChannelMapper.java
@@ -378,7 +378,7 @@ public interface DeviceChannelMapper {
             " from wvp_device_channel where device_db_id = #{deviceDbId}")
     List<DeviceChannel> queryAllChannelsForRefresh(@Param("deviceDbId") int deviceDbId);
 
-    @Select("select de.* from wvp_device de left join wvp_device_channel dc on de.device_id = dc.deviceId where dc.device_id=#{channelId}")
+    @Select("select de.* from wvp_device de left join wvp_device_channel dc on de.device_id = dc.device_id where dc.device_id=#{channelId}")
     List<Device> getDeviceByChannelDeviceId(String channelId);
 
 


### PR DESCRIPTION
#### 更改内容：
在 `getDeviceByChannelDeviceId` 方法中的 SQL 查询中，修复了错误的字段名引用，将 `dc.deviceId` 改为 `dc.device_id`，以符合数据库 `wvp_device_channel` 表的字段命名规则。

```java
// 修改前：
de.device_id = dc.deviceId

// 修改后：
de.device_id = dc.device_id