### PR TITLE
国标设备管理新增设备编号查询条件

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/controller/DeviceQuery.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/controller/DeviceQuery.java
@@ -97,14 +97,15 @@ public class DeviceQuery {
 	@Parameter(name = "page", description = "当前页", required = true)
 	@Parameter(name = "count", description = "每页查询数量", required = true)
 	@Parameter(name = "query", description = "搜索", required = false)
+	@Parameter(name = "deviceId", description = "设备编号", required = false)
 	@Parameter(name = "status", description = "状态", required = false)
 	@GetMapping("/devices")
 	@Options()
-	public PageInfo<Device> devices(int page, int count, String query, Boolean status){
+	public PageInfo<Device> devices(int page, int count, String query, String deviceId, Boolean status){
 		if (ObjectUtils.isEmpty(query)){
 			query = null;
 		}
-		return deviceService.getAll(page, count, query, status);
+		return deviceService.getAll(page, count, query, deviceId, status);
 	}
 
 	/**

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/dao/DeviceMapper.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/dao/DeviceMapper.java
@@ -340,10 +340,11 @@ public interface DeviceMapper {
             " FROM wvp_device de" +
             " where 1 = 1 "+
             " <if test='status != null'> AND de.on_line=${status}</if>"+
+            " <if test='deviceId != null'> AND de.device_id=#{deviceId}</if>"+
             " <if test='query != null'> AND coalesce(custom_name, name) LIKE '%${query}%'</if> " +
             " order by create_time desc "+
             " </script>")
-    List<Device> getDeviceList(@Param("query") String query, @Param("status") Boolean status);
+    List<Device> getDeviceList(@Param("query") String query, @Param("deviceId") String deviceId, @Param("status") Boolean status);
 
     @Select("select * from wvp_device_channel where id = #{id}")
     DeviceChannel getRawChannel(@Param("id") int id);

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/service/IDeviceService.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/service/IDeviceService.java
@@ -154,7 +154,7 @@ public interface IDeviceService {
      */
     List<Device> getAll();
 
-    PageInfo<Device> getAll(int page, int count, String query, Boolean status);
+    PageInfo<Device> getAll(int page, int count, String query, String deviceId, Boolean status);
 
     Device getDevice(Integer gbDeviceDbId);
 

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/service/impl/DeviceServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/service/impl/DeviceServiceImpl.java
@@ -548,9 +548,9 @@ public class DeviceServiceImpl implements IDeviceService {
     }
 
     @Override
-    public PageInfo<Device> getAll(int page, int count, String query, Boolean status) {
+    public PageInfo<Device> getAll(int page, int count, String query, String deviceId, Boolean status) {
         PageHelper.startPage(page, count);
-        List<Device> all = deviceMapper.getDeviceList(query, status);
+        List<Device> all = deviceMapper.getDeviceList(query, deviceId, status);
         return new PageInfo<>(all);
     }
 

--- a/web_src/src/components/DeviceList.vue
+++ b/web_src/src/components/DeviceList.vue
@@ -6,6 +6,9 @@
         搜索:
         <el-input @input="getDeviceList" style="margin-right: 1rem; width: auto;" size="mini" placeholder="关键字"
                   prefix-icon="el-icon-search" v-model="searchSrt" clearable></el-input>
+        设备编号:
+        <el-input @input="getDeviceList" style="margin-right: 1rem; width: auto;" size="mini" placeholder="设备编号"
+                  prefix-icon="el-icon-search" v-model="deviceId" clearable></el-input>
         在线状态:
         <el-select size="mini" style="width: 8rem; margin-right: 1rem;" @change="getDeviceList" v-model="online" placeholder="请选择"
                    default-first-option>
@@ -118,6 +121,7 @@ export default {
       deviceList: [], //设备列表
       currentDevice: {}, //当前操作设备对象
       searchSrt: "",
+      deviceId: "",
       online: null,
       videoComponentList: [],
       updateLooper: 0, //数据刷新轮训标志
@@ -171,6 +175,7 @@ export default {
           page: this.currentPage,
           count: this.count,
           query: this.searchSrt,
+          deviceId: this.deviceId,
           status: this.online,
         }
       }).then( (res)=> {


### PR DESCRIPTION
实际使用过程中，一但超过几百个设备打开国标设备管理页面想要查找某个设备变得很麻烦，增加国标设备编号过滤查询#1644 