### PR TITLE
修复编译时 maven 可能提示“找不到符号”的问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,13 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.30</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
有些版本的 JDK 和 Maven 编译项目时不会自动生成对应的 setter 和 getter 方法，导致编译提示“找不到符号”