### PR TITLE
Introduced protections against predictable RNG abuse

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/conf/redis/RedisRpcConfig.java
+++ b/src/main/java/com/genersoft/iot/vmp/conf/redis/RedisRpcConfig.java
@@ -7,6 +7,7 @@ import com.genersoft.iot.vmp.conf.redis.bean.RedisRpcMessage;
 import com.genersoft.iot.vmp.conf.redis.bean.RedisRpcRequest;
 import com.genersoft.iot.vmp.conf.redis.bean.RedisRpcResponse;
 import com.genersoft.iot.vmp.service.redisMsg.control.RedisRpcController;
+import java.security.SecureRandom;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -31,7 +32,7 @@ public class RedisRpcConfig implements MessageListener {
 
     public final static String REDIS_REQUEST_CHANNEL_KEY = "WVP_REDIS_REQUEST_CHANNEL_KEY";
 
-    private final Random random = new Random();
+    private final Random random = new SecureRandom();
 
     @Autowired
     private UserSetting userSetting;

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/auth/DigestServerAuthenticationHelper.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/auth/DigestServerAuthenticationHelper.java
@@ -26,6 +26,7 @@
 package com.genersoft.iot.vmp.gb28181.auth;
 
 import gov.nist.core.InternalErrorHandler;
+import java.security.SecureRandom;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.sip.address.URI;
@@ -83,7 +84,7 @@ public class DigestServerAuthenticationHelper  {
      */
     private String generateNonce() {
         long time = Instant.now().toEpochMilli();
-        Random rand = new Random();
+        Random rand = new SecureRandom();
         long pad = rand.nextLong();
         String nonceString = Long.valueOf(time).toString()
                 + Long.valueOf(pad).toString();

--- a/src/main/java/com/genersoft/iot/vmp/jt1078/cmd/JT1078Template.java
+++ b/src/main/java/com/genersoft/iot/vmp/jt1078/cmd/JT1078Template.java
@@ -3,6 +3,7 @@ package com.genersoft.iot.vmp.jt1078.cmd;
 import com.genersoft.iot.vmp.jt1078.proc.entity.Cmd;
 import com.genersoft.iot.vmp.jt1078.proc.response.*;
 import com.genersoft.iot.vmp.jt1078.session.SessionManager;
+import java.security.SecureRandom;
 
 import java.util.Random;
 
@@ -13,7 +14,7 @@ import java.util.Random;
  */
 public class JT1078Template {
 
-    private final Random random = new Random();
+    private final Random random = new SecureRandom();
 
     private static final String H9101 = "9101";
     private static final String H9102 = "9102";


### PR DESCRIPTION
This change replaces all new instances of `java.util.Random` with the marginally slower, but much more secure `java.security.SecureRandom`.

We have to work pretty hard to get computers to generate genuinely unguessable random bits. The `java.util.Random` type uses a method of pseudo-random number generation that unfortunately emits fairly predictable numbers.

If the numbers it emits are predictable, then it's obviously not safe to use in cryptographic operations, file name creation, token construction, password generation, and anything else that's related to security. In fact, it may affect security even if it's not directly obvious.

Switching to a more secure version is simple and our changes all look something like this:

```diff
- Random r = new Random();
+ Random r = new java.security.SecureRandom();
```

<details>
  <summary>More reading</summary>

  * [https://owasp.org/www-community/vulnerabilities/Insecure_Randomness](https://owasp.org/www-community/vulnerabilities/Insecure_Randomness)
  * [https://metebalci.com/blog/everything-about-javas-securerandom/](https://metebalci.com/blog/everything-about-javas-securerandom/)
  * [https://cwe.mitre.org/data/definitions/330.html](https://cwe.mitre.org/data/definitions/330.html)
</details>
