### PR TITLE
[BUG] 修复执行录像计划定时任务时，没有录像任务导致的java.util.ConcurrentModificationException

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/service/impl/RecordPlanServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/impl/RecordPlanServiceImpl.java
@@ -89,7 +89,8 @@ public class RecordPlanServiceImpl implements IRecordPlanService {
         if (startChannelIdList.isEmpty()) {
             // 当前没有录像任务, 如果存在旧的正在录像的就移除
             if(!recordStreamMap.isEmpty()) {
-                stopStreams(recordStreamMap.keySet(), recordStreamMap);
+                Set<Integer> recordStreamSet = new HashSet<>(recordStreamMap.keySet());
+                stopStreams(recordStreamSet, recordStreamMap);
                 recordStreamMap.clear();
             }
         }else {


### PR DESCRIPTION
报错内容：
```
java.util.ConcurrentModificationException: null
        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1469)
        at java.util.HashMap$KeyIterator.next(HashMap.java:1493)
        at com.genersoft.iot.vmp.service.impl.RecordPlanServiceImpl.stopStreams(RecordPlanServiceImpl.java:143)
        at com.genersoft.iot.vmp.service.impl.RecordPlanServiceImpl.execution(RecordPlanServiceImpl.java:92)
```

做出的修改：
按照下面的逻辑搬上来了