### PR TITLE
修复CatalogEventLister未判空ServerGBId引发的空指针异常

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/event/subscribe/catalog/CatalogEventLister.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/event/subscribe/catalog/CatalogEventLister.java
@@ -44,6 +44,9 @@ public class CatalogEventLister implements ApplicationListener<CatalogEvent> {
         Map<String, CommonGBChannel> channelMap = new HashMap<>();
         if (event.getPlatform() != null) {
             parentPlatform = event.getPlatform();
+            if (parentPlatform.getServerGBId() == null) {
+                return;
+            }
             subscribe = subscribeHolder.getCatalogSubscribe(parentPlatform.getServerGBId());
             if (subscribe == null) {
                 return;


### PR DESCRIPTION
下级平台为海康的监管平台，设备全部注册成功。在此基础上使用国标级联向更上级推送，点击同步设备状态时，必现设备同步死循环，且控制台报错NullPointExcepiton。经过远程debug，锁定此处问题。