### PR TITLE
knife4j文档中描述使用相对地址，可以直接点击打开对应页面

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/conf/SpringDocConfig.java
+++ b/src/main/java/com/genersoft/iot/vmp/conf/SpringDocConfig.java
@@ -39,9 +39,9 @@ public class SpringDocConfig {
                 .info(new Info().title("WVP-PRO 接口文档")
                         .contact(contact)
                         .description("开箱即用的28181协议视频平台。 <br/>" +
-                                "1. 打开http://127.0.0.1:18080/doc.html#/1.%20全部/用户管理/login_1" +
+                                "1. 打开<a href='/doc.html#/1.%20全部/用户管理/login_1'>登录</a>接口" +
                                 " 登录成功后返回AccessToken。 <br/>" +
-                                "2. 填写到AccessToken到参数值 http://127.0.0.1:18080/doc.html#/Authorize/1.%20全部  <br/>" +
+                                "2. 填写到AccessToken到参数值 <a href='/doc.html#/Authorize/1.%20全部'>Token配置</a>  <br/>" +
                                 "后续接口就可以直接测试了")
                         .version("v3.1.0")
                         .license(new License().name("Apache 2.0").url("http://springdoc.org")));


### PR DESCRIPTION
如题，不排除用户更换端口导致链接点击没有用。

更改后，使用相对链接跳转，适用于各种情况。