### PR TITLE
支持关闭返回Date Header，进而实现关闭对摄像头的校时功能

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/conf/UserSetting.java
+++ b/src/main/java/com/genersoft/iot/vmp/conf/UserSetting.java
@@ -204,6 +204,9 @@ public class UserSetting {
      */
     private boolean sipCacheServerConnections = true;
 
-
+    /**
+     * 禁用date头，变相禁用了校时
+     */
+    private boolean disableDateHeader = false;
 
 }

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/RegisterRequestProcessor.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/RegisterRequestProcessor.java
@@ -144,12 +144,15 @@ public class RegisterRequestProcessor extends SIPRequestProcessorParent implemen
 
             // 携带授权头并且密码正确
             response = getMessageFactory().createResponse(Response.OK, request);
-            // 添加date头
-            SIPDateHeader dateHeader = new SIPDateHeader();
-            // 使用自己修改的
-            GbSipDate gbSipDate = new GbSipDate(Calendar.getInstance(Locale.ENGLISH).getTimeInMillis());
-            dateHeader.setDate(gbSipDate);
-            response.addHeader(dateHeader);
+            // 如果主动禁用了Date头，则不添加
+            if (!userSetting.isDisableDateHeader()) {
+                // 添加date头
+                SIPDateHeader dateHeader = new SIPDateHeader();
+                // 使用自己修改的
+                GbSipDate gbSipDate = new GbSipDate(Calendar.getInstance(Locale.ENGLISH).getTimeInMillis());
+                dateHeader.setDate(gbSipDate);
+                response.addHeader(dateHeader);
+            }
 
             if (request.getExpires() == null) {
                 response = getMessageFactory().createResponse(Response.BAD_REQUEST, request);
@@ -218,12 +221,15 @@ public class RegisterRequestProcessor extends SIPRequestProcessorParent implemen
     private Response getRegisterOkResponse(Request request) throws ParseException {
         // 携带授权头并且密码正确
         Response response = getMessageFactory().createResponse(Response.OK, request);
-        // 添加date头
-        SIPDateHeader dateHeader = new SIPDateHeader();
-        // 使用自己修改的
-        GbSipDate gbSipDate = new GbSipDate(Calendar.getInstance(Locale.ENGLISH).getTimeInMillis());
-        dateHeader.setDate(gbSipDate);
-        response.addHeader(dateHeader);
+        // 如果主动禁用了Date头，则不添加
+        if (!userSetting.isDisableDateHeader()) {
+            // 添加date头
+            SIPDateHeader dateHeader = new SIPDateHeader();
+            // 使用自己修改的
+            GbSipDate gbSipDate = new GbSipDate(Calendar.getInstance(Locale.ENGLISH).getTimeInMillis());
+            dateHeader.setDate(gbSipDate);
+            response.addHeader(dateHeader);
+        }
 
         // 添加Contact头
         response.addHeader(request.getHeader(ContactHeader.NAME));

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -90,4 +90,6 @@ user-settings:
   record-sip: true
   # 国标点播 按需拉流, true：有人观看拉流，无人观看释放， false：拉起后不自动释放
   stream-on-demand: true
+  # 是否返回Date属性，true：不返回，避免摄像头通过该参数自动校时，false：返回，摄像头可能会根据该时间校时
+  disable-date-header: false
 


### PR DESCRIPTION
Fixes #1700

修改`application.yml`文件，设置`user-settings.disable-date-header`为`true`时，不向sip `header`中添加Date Header，避免摄像头自动校时，测试大华设备和第三方GB28281兼容设备在关闭校时时仍可注册。