### PR TITLE
支持自定义ZLM播放URL

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/common/StreamInfo.java
+++ b/src/main/java/com/genersoft/iot/vmp/common/StreamInfo.java
@@ -5,10 +5,14 @@ import com.genersoft.iot.vmp.media.bean.MediaServer;
 import com.genersoft.iot.vmp.service.bean.DownloadFileInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
+import java.net.URL;
 import java.util.Objects;
 
+@Slf4j
 @Data
 @Schema(description = "流信息")
 public class StreamInfo implements Serializable, Cloneable{
@@ -254,6 +258,112 @@ public class StreamInfo implements Serializable, Cloneable{
         }
         if (this.rtmps != null) {
             this.rtmps.setHost(localAddr);
+        }
+    }
+
+    public void changeStreamPrefix(URL url) {
+        if (url.getProtocol() == null) {
+            return;
+        }
+        String newPrefix = url.getPath();
+        if (newPrefix.startsWith("/")) {
+            newPrefix = newPrefix.substring(1);
+        }
+        if (StringUtils.isNotBlank(newPrefix) && !newPrefix.endsWith("/")) {
+            newPrefix = newPrefix + "/";
+        }
+        if (url.getProtocol().equalsIgnoreCase("http")) {
+            // 修改http部分
+            if (this.flv != null) {
+                this.flv.setHost(url.getHost());
+                this.flv.setPort(url.getPort());
+                this.flv.setFile(newPrefix + this.flv.getFile());
+            }
+            if (this.ws_flv != null ){
+                this.ws_flv.setHost(url.getHost());
+                this.ws_flv.setPort(url.getPort());
+                this.ws_flv.setFile(newPrefix + this.flv.getFile());
+            }
+            if (this.hls != null ) {
+                this.hls.setHost(url.getHost());
+                this.hls.setPort(url.getPort());
+                this.hls.setFile(newPrefix + this.hls.getFile());
+            }
+            if (this.ws_hls != null ) {
+                this.ws_hls.setHost(url.getHost());
+                this.ws_hls.setPort(url.getPort());
+                this.ws_hls.setFile(newPrefix + this.hls.getFile());
+            }
+            if (this.ts != null ) {
+                this.ts.setHost(url.getHost());
+                this.ts.setPort(url.getPort());
+                this.ts.setFile(newPrefix + this.ts.getFile());
+            }
+            if (this.ws_ts != null ) {
+                this.ws_ts.setHost(url.getHost());
+                this.ws_ts.setPort(url.getPort());
+                this.ws_ts.setFile(newPrefix + this.ts.getFile());
+            }
+            if (this.fmp4 != null ) {
+                this.fmp4.setHost(url.getHost());
+                this.fmp4.setPort(url.getPort());
+                this.fmp4.setFile(newPrefix + this.fmp4.getFile());
+            }
+            if (this.ws_fmp4 != null ) {
+                this.ws_fmp4.setHost(url.getHost());
+                this.ws_fmp4.setPort(url.getPort());
+                this.ws_fmp4.setFile(newPrefix + this.fmp4.getFile());
+            }
+        } else if (url.getProtocol().equalsIgnoreCase("https")) {
+            if (this.https_flv != null) {
+                this.https_flv.setHost(url.getHost());
+                this.https_flv.setPort(url.getPort());
+                this.https_flv.setFile(newPrefix + this.https_flv.getFile());
+            } else if (this.flv != null) { // 为什么设置这个，因为你既然有https的地址，那http/ws相关的内容都被代理了
+                this.https_flv = new StreamURL("https", url.getHost(), url.getPort(), newPrefix + this.flv.getFile());
+            }
+            if (this.wss_flv != null) {
+                this.wss_flv.setHost(url.getHost());
+                this.wss_flv.setPort(url.getPort());
+                this.wss_flv.setFile(newPrefix + this.wss_flv.getFile());
+            } else if (this.ws_flv != null) {
+                this.wss_flv = new StreamURL("wss", url.getHost(), url.getPort(), newPrefix + this.ws_flv.getFile());
+            }
+            if (this.https_hls != null) {
+                this.https_hls.setHost(url.getHost());
+                this.https_hls.setPort(url.getPort());
+                this.https_hls.setFile(newPrefix + this.https_hls.getFile());
+            } else if (this.hls != null) {
+                this.https_hls = new StreamURL("https", url.getHost(), url.getPort(), newPrefix + this.hls.getFile());
+            }
+            if (this.wss_hls != null) {
+                this.wss_hls.setHost(url.getHost());
+                this.wss_hls.setPort(url.getPort());
+                this.wss_hls.setFile(newPrefix + this.wss_hls.getFile());
+            } else if (this.ws_hls != null) {
+                this.wss_hls = new StreamURL("wss", url.getHost(), url.getPort(), newPrefix + this.ws_hls.getFile());
+            }
+            if (this.wss_ts != null) {
+                this.wss_ts.setHost(url.getHost());
+                this.wss_ts.setPort(url.getPort());
+                this.wss_ts.setFile(newPrefix + this.wss_ts.getFile());
+            } else if (this.ws_ts != null) {
+                this.wss_ts = new StreamURL("wss", url.getHost(), url.getPort(), newPrefix + this.ws_ts.getFile());
+            }
+            if (this.https_fmp4 != null) {
+                this.https_fmp4.setHost(url.getHost());
+                this.https_fmp4.setPort(url.getPort());
+                this.https_fmp4.setFile(newPrefix + this.https_fmp4.getFile());
+            } else if (this.fmp4 != null) {
+                this.https_fmp4 = new StreamURL("https", url.getHost(), url.getPort(), newPrefix + this.fmp4.getFile());
+            }
+            if (this.wss_fmp4 != null) {
+                this.wss_fmp4.setHost(url.getHost());
+                this.wss_fmp4.setPort(url.getPort());
+                this.wss_fmp4.setFile(newPrefix + this.wss_fmp4.getFile());
+            } else if (this.ws_fmp4 != null) {
+                this.wss_fmp4 = new StreamURL("wss", url.getHost(), url.getPort(), newPrefix + this.ws_fmp4.getFile());
+            }
         }
     }
 

--- a/src/main/java/com/genersoft/iot/vmp/common/StreamURL.java
+++ b/src/main/java/com/genersoft/iot/vmp/common/StreamURL.java
@@ -71,8 +71,12 @@ public class StreamURL implements Serializable,Cloneable {
 
     @Override
     public String toString() {
-        if (protocol != null && host != null && port != -1 ) {
-            return String.format("%s://%s:%s/%s", protocol, host, port, file);
+        if (protocol != null && host != null) {
+            if (port != -1) {
+                return String.format("%s://%s:%s/%s", protocol, host, port, file);
+            } else {
+                return String.format("%s://%s/%s", protocol, host, file);
+            }
         }else {
             return null;
         }

--- a/src/main/java/com/genersoft/iot/vmp/conf/UserSetting.java
+++ b/src/main/java/com/genersoft/iot/vmp/conf/UserSetting.java
@@ -204,6 +204,9 @@ public class UserSetting {
      */
     private boolean sipCacheServerConnections = true;
 
-
+    /**
+     * 自定义流地址前缀，方便被nginx代理，如：https://zlm.example.com/a
+     */
+    private String customStreamUrl = "";
 
 }

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/controller/CommonChannelController.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/controller/CommonChannelController.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
@@ -297,6 +298,14 @@ public class CommonChannelController {
                             host=request.getLocalAddr();
                         }
                         streamInfo.changeStreamIp(host);
+                    } else if (StringUtils.isNotBlank(userSetting.getCustomStreamUrl())) {
+                        streamInfo=streamInfo.clone();//深拷贝
+                        try {
+                            URL url=new URL(userSetting.getCustomStreamUrl());
+                            streamInfo.changeStreamPrefix(url);
+                        } catch (MalformedURLException e) {
+                            log.warn("[配置错误]customStreamUrl异常！异常值为：{}", userSetting.getCustomStreamUrl());
+                        }
                     }
                     if (!ObjectUtils.isEmpty(streamInfo.getMediaServer().getTranscodeSuffix())
                             && !"null".equalsIgnoreCase(streamInfo.getMediaServer().getTranscodeSuffix())) {

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/controller/PlayController.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/controller/PlayController.java
@@ -31,6 +31,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
@@ -124,6 +125,14 @@ public class PlayController {
 							host=request.getLocalAddr();
 						}
 						streamInfo.changeStreamIp(host);
+					} else if (StringUtils.isNotBlank(userSetting.getCustomStreamUrl())) {
+						streamInfo=streamInfo.clone();//深拷贝
+						try {
+							URL url=new URL(userSetting.getCustomStreamUrl());
+							streamInfo.changeStreamPrefix(url);
+						} catch (MalformedURLException e) {
+							log.warn("[配置错误]customStreamUrl异常！异常值为：{}", userSetting.getCustomStreamUrl());
+						}
 					}
 					if (!ObjectUtils.isEmpty(streamInfo.getMediaServer().getTranscodeSuffix()) && !"null".equalsIgnoreCase(streamInfo.getMediaServer().getTranscodeSuffix())) {
 						streamInfo.setStream(streamInfo.getStream() + "_" + streamInfo.getMediaServer().getTranscodeSuffix());

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/controller/PlaybackController.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/controller/PlaybackController.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -123,6 +124,14 @@ public class PlaybackController {
 									host=request.getLocalAddr();
 								}
 								streamInfo.changeStreamIp(host);
+							} else if (StringUtils.isNotBlank(userSetting.getCustomStreamUrl())) {
+								streamInfo=streamInfo.clone();//深拷贝
+								try {
+									URL url=new URL(userSetting.getCustomStreamUrl());
+									streamInfo.changeStreamPrefix(url);
+								} catch (MalformedURLException e) {
+									log.warn("[配置错误]customStreamUrl异常！异常值为：{}", userSetting.getCustomStreamUrl());
+								}
 							}
 							wvpResult.setData(new StreamContent(streamInfo));
 						}

--- a/src/main/java/com/genersoft/iot/vmp/streamProxy/controller/StreamProxyController.java
+++ b/src/main/java/com/genersoft/iot/vmp/streamProxy/controller/StreamProxyController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.bind.annotation.*;
@@ -209,6 +210,14 @@ public class StreamProxyController {
                     host=request.getLocalAddr();
                 }
                 streamInfo.changeStreamIp(host);
+            } else if (StringUtils.isNotBlank(userSetting.getCustomStreamUrl())) {
+                streamInfo=streamInfo.clone();//深拷贝
+                try {
+                    URL url=new URL(userSetting.getCustomStreamUrl());
+                    streamInfo.changeStreamPrefix(url);
+                } catch (MalformedURLException e) {
+                    log.warn("[配置错误]customStreamUrl异常！异常值为：{}", userSetting.getCustomStreamUrl());
+                }
             }
             return new StreamContent(streamInfo);
         }

--- a/src/main/java/com/genersoft/iot/vmp/streamPush/controller/StreamPushController.java
+++ b/src/main/java/com/genersoft/iot/vmp/streamPush/controller/StreamPushController.java
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -267,6 +268,14 @@ public class StreamPushController {
                         host=request.getLocalAddr();
                     }
                     streamInfo.changeStreamIp(host);
+                } else if (StringUtils.isNotBlank(userSetting.getCustomStreamUrl())) {
+                    streamInfo=streamInfo.clone();//深拷贝
+                    try {
+                        URL url=new URL(userSetting.getCustomStreamUrl());
+                        streamInfo.changeStreamPrefix(url);
+                    } catch (MalformedURLException e) {
+                        log.warn("[配置错误]customStreamUrl异常！异常值为：{}", userSetting.getCustomStreamUrl());
+                    }
                 }
                 WVPResult<StreamContent> success = WVPResult.success(new StreamContent(streamInfo));
                 result.setResult(success);

--- a/src/main/java/com/genersoft/iot/vmp/vmanager/cloudRecord/CloudRecordController.java
+++ b/src/main/java/com/genersoft/iot/vmp/vmanager/cloudRecord/CloudRecordController.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.async.DeferredResult;
@@ -288,6 +289,14 @@ public class CloudRecordController {
                             host=request.getLocalAddr();
                         }
                         streamInfo.changeStreamIp(host);
+                    } else if (StringUtils.isNotBlank(userSetting.getCustomStreamUrl())) {
+                        streamInfo=streamInfo.clone();//深拷贝
+                        try {
+                            URL url=new URL(userSetting.getCustomStreamUrl());
+                            streamInfo.changeStreamPrefix(url);
+                        } catch (MalformedURLException e) {
+                            log.warn("[配置错误]customStreamUrl异常！异常值为：{}", userSetting.getCustomStreamUrl());
+                        }
                     }
                     if (!org.springframework.util.ObjectUtils.isEmpty(streamInfo.getMediaServer().getTranscodeSuffix()) && !"null".equalsIgnoreCase(streamInfo.getMediaServer().getTranscodeSuffix())) {
                         streamInfo.setStream(streamInfo.getStream() + "_" + streamInfo.getMediaServer().getTranscodeSuffix());

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -90,4 +90,6 @@ user-settings:
   record-sip: true
   # 国标点播 按需拉流, true：有人观看拉流，无人观看释放， false：拉起后不自动释放
   stream-on-demand: true
+  # 自定义流地址前缀，方便zlm已被nginx代理，如：https://zlm.example.com/a/
+  custom-stream-url: ''
 


### PR DESCRIPTION
添加了配置`user-settings.custom-stream-url`，填写对应的http域名或https域名即可，会处理http或https的url，前端播放逻辑仍然需要前端自己判断
例如：http://zlm.example.com/ ，则只会对http相关(http/ws)的链接进行更改，https://zlm.example.com/，则会对https相关的链接做修改。
支持子路径，填写http://example.com/zlm 会把域名换成http://example.com 并在url前面添加zlm/(例如http://example.com/zlm/rtp/_device_id__channel_id/hls.m3u8)

只修改了和zlm相关的云录像、回放、设备播放、全局通道的通道播放、拉流代理、推流列表中的地址，其他我这边没法测试……就没改

增加port=-1的情况，直接不在URL上体现