### PR TITLE
添加github action打包功能

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [amd64, arm64]
-      max-parallel: 1 # 最大并行数 这样amd和arm的打包不会互相影响
+        arch: [amd64]
+      max-parallel: 1 # 最大并行数
     steps:
       - name: Checkout
         uses: actions/checkout@v4 # github action运行环境
@@ -54,10 +54,23 @@ jobs:
           cp -r ./src/main/resources/static release/  # 复制前端文件
           cp ./target/*.jar release/     # 复制 JAR 文件
           cp ./src/main/resources/application-dev.yml release
-          zip -r release-ubuntu-${{ matrix.arch }}.zip release
+          
+          BRANCH=${{ github.event.base_ref }}
+          BRANCH_NAME=$(echo "$BRANCH" | grep -oP 'refs/heads/\K.*')
+          echo "BRANCH_NAME= ${BRANCH_NAME}"
+          # 如果无法获取，使用默认分支
+          if [[ -z "BRANCH_NAME" ]]; then
+            BRANCH_NAME="${{ github.event.repository.default_branch }}"
+          fi
+          
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          DATE=$(date +%Y%m%d)
+          ZIP_FILE_NAME="${BRANCH_NAME}-${TAG_NAME}-${DATE}.zip"
+          zip -r "$ZIP_FILE_NAME" release
+          echo "ZIP_FILE_NAME=$ZIP_FILE_NAME" >> $GITHUB_ENV
 
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: release-ubuntu-${{ matrix.arch }}.zip
+          files: ${{ env.ZIP_FILE_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,63 @@
+name: release-ubuntu
+
+on:
+  push:
+    tags:
+      - "v*.*.*" # 触发条件是推送标签 如git tag v2.7.4 git push origin v2.7.4
+
+jobs:
+  build-ubuntu:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+      max-parallel: 1 # 最大并行数 这样amd和arm的打包不会互相影响
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4 # github action运行环境
+
+      - name: Create release # 创建文件夹
+        run: |
+          rm -rf release 
+          mkdir release
+          echo ${{ github.sha }} > Release.txt
+          cp Release.txt LICENSE release/
+          cat Release.txt
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v4
+        with:
+          # Eclipse基金会维护的开源Java发行版 因为github action参考java的用这个 所以用这个
+          # 还有microsoft(微软维护的openjdk发行版) oracle(商用SDK)等
+          distribution: 'temurin'
+          java-version: '8'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x' # Node.js版本 20系列的最新稳定版
+
+      - name: Compile backend
+        run: |
+          mvn package
+          mvn package -P war
+
+      - name: Compile frontend
+        run: |
+          cd ./web
+          npm install
+          npm run build:prod
+          cd ../
+
+      - name: Package Files
+        run: |
+          cp -r ./src/main/resources/static release/  # 复制前端文件
+          cp ./target/*.jar release/     # 复制 JAR 文件
+          cp ./src/main/resources/application-dev.yml release
+          zip -r release-ubuntu-${{ matrix.arch }}.zip release
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: release-ubuntu-${{ matrix.arch }}.zip


### PR DESCRIPTION
- 目前不使用任何缓存打包保证不容易错误 但是打包速度较慢 需要几分钟
- 目前打包使用jdk8和nodejs 20.x

<img width="1201" alt="image" src="https://github.com/user-attachments/assets/64941457-4975-4c58-9b12-be3e28a97373" />

发布新版本的时候打包 如下
```
git tag v2.7.5
git push origin v2.7.5
```

- 压缩包的内容如图

<img width="840" alt="image" src="https://github.com/user-attachments/assets/15724652-b195-4ba0-8e4e-4d754a997b14" />

- 目前只测试了amd的情况 未测试arm的(无arm设备)

<img width="1722" alt="image" src="https://github.com/user-attachments/assets/7b5cba87-bbfb-4574-83a9-f2b3e7cc3675" />
