### PR TITLE
[后端] 修复目录设置/位置移动的订阅逻辑：订阅周期必须 ≥30 秒，取消订阅时允许周期设为 0

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/cmd/impl/SIPCommander.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/cmd/impl/SIPCommander.java
@@ -1203,7 +1203,13 @@ public class SIPCommander implements ISIPCommander {
         } else {
             callIdHeader = sipSender.getNewCallIdHeader(sipLayer.getLocalIp(device.getLocalIp()),device.getTransport());
         }
-        SIPRequest request = (SIPRequest) headerProvider.createSubscribeRequest(device, subscribePostitionXml.toString(), sipTransactionInfo, device.getSubscribeCycleForMobilePosition(), "presence",callIdHeader); //Position;id=" + tm.substring(tm.length() - 4));
+
+        int subscribeCycleForMobilePosition = device.getSubscribeCycleForMobilePosition();
+        if (subscribeCycleForMobilePosition > 0) {
+            // 移动位置订阅有效期不小于 30 秒
+            subscribeCycleForMobilePosition = Math.max(subscribeCycleForMobilePosition, 30);
+        }
+        SIPRequest request = (SIPRequest) headerProvider.createSubscribeRequest(device, subscribePostitionXml.toString(), sipTransactionInfo, subscribeCycleForMobilePosition, "presence",callIdHeader); //Position;id=" + tm.substring(tm.length() - 4));
 
         sipSender.transmitRequest(sipLayer.getLocalIp(device.getLocalIp()), request, errorEvent, okEvent);
         return request;
@@ -1275,8 +1281,13 @@ public class SIPCommander implements ISIPCommander {
             callIdHeader = sipSender.getNewCallIdHeader(sipLayer.getLocalIp(device.getLocalIp()),device.getTransport());
         }
 
+        int subscribeCycleForCatalog = device.getSubscribeCycleForCatalog();
+        if (subscribeCycleForCatalog > 0) {
+            // 目录订阅有效期不小于 30 秒
+            subscribeCycleForCatalog = Math.max(subscribeCycleForCatalog, 30);
+        }
         // 有效时间默认为60秒以上
-        SIPRequest request = (SIPRequest) headerProvider.createSubscribeRequest(device, cmdXml.toString(), sipTransactionInfo, device.getSubscribeCycleForCatalog(), "Catalog",
+        SIPRequest request = (SIPRequest) headerProvider.createSubscribeRequest(device, cmdXml.toString(), sipTransactionInfo, subscribeCycleForCatalog, "Catalog",
                 callIdHeader);
         sipSender.transmitRequest(sipLayer.getLocalIp(device.getLocalIp()), request, errorEvent, okEvent);
         return request;


### PR DESCRIPTION
当前使用 master 分支（截止 2024-12-30）的代码时发现，
在目录订阅和移动位置订阅中，如果订阅周期设置 <30s，
设备状态和移动位置更新会出现 (30 - 实际设置值) s 左右延迟。

原因：原代码中强制设置了最小订阅周期 30s。
修复：增加实际生成订阅报文时候的最小订阅周期限制。