### PR TITLE
插入wvp_media_server表数据时，server_id为空的兜底机制

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/media/service/impl/MediaServerServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/media/service/impl/MediaServerServiceImpl.java
@@ -508,7 +508,9 @@ public class MediaServerServiceImpl implements IMediaServerService {
             log.info("[添加媒体节点] 失败, mediaServer的类型： {}，未找到对应的实现类", mediaServer.getType());
             return;
         }
-
+        if(mediaServer.getServerId().isEmpty()){
+            mediaServer.setServerId(userSetting.getServerId());
+        }
         mediaServerMapper.add(mediaServer);
         if (mediaServer.isStatus()) {
             mediaNodeServerService.online(mediaServer);


### PR DESCRIPTION
在我的本地测试中，我发现在一些情况下mediaServerMapper.add(mediaServer);的时候server_id的值是null，导致插入的那条数据当中servera_id没有，在后续的以id和server_id为条件查询wvp_media_server表时并不能查找到数据(所以不是执行更新的操作)，此后程序会进行插入操作，但是插入的那条数据id会与之前插入的那条数据的id相同，导致报错主键冲突，我加的这两段代码是做的最后的一个兜底的工作，如果在之前因为某种原由导致mediaServer中的server_id为null的时候也能有最后的兜底，不至于后面插入数据的时候抛出异常
<img width="1830" height="711" alt="c717bfebabe8e21cd7089d4d2394616" src="https://github.com/user-attachments/assets/8c4bb0ae-d0f2-44ed-a596-662e79bc5b7b" />
