### PR TITLE
fix: 修复国标目录通知导致的孤儿通道重复,一个设备下生成两条重复的通道,一个正常一个不正常

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/dao/DeviceChannelMapper.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/dao/DeviceChannelMapper.java
@@ -103,6 +103,13 @@ public interface DeviceChannelMapper {
     @Delete("DELETE FROM wvp_device_channel WHERE data_type =1 and data_device_id=#{dataDeviceId}")
     int cleanChannelsByDeviceId(@Param("dataDeviceId") int dataDeviceId);
 
+    @Delete("<script> " +
+            "DELETE FROM wvp_device_channel " +
+            "WHERE data_type = 1 AND data_device_id <= 0 AND device_id in " +
+            "<foreach item='item' index='index' collection='deviceIds' open='(' separator=',' close=')'> #{item} </foreach>" +
+            "</script>")
+    int cleanOrphanChannelsByDeviceIds(@Param("deviceIds") List<String> deviceIds);
+
     @Delete("DELETE FROM wvp_device_channel WHERE data_type=#{dataType} and data_device_id=#{dataDeviceId} AND device_id=#{deviceId}")
     int deleteForNotify(DeviceChannel channel);
 

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/service/impl/DeviceChannelServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/service/impl/DeviceChannelServiceImpl.java
@@ -391,6 +391,18 @@ public class DeviceChannelServiceImpl implements IDeviceChannelService {
         if (CollectionUtils.isEmpty(deviceChannelList)) {
             return false;
         }
+        Set<String> channelDeviceIds = new HashSet<>();
+        for (DeviceChannel deviceChannel : deviceChannelList) {
+            if (deviceChannel != null && !ObjectUtils.isEmpty(deviceChannel.getDeviceId())) {
+                channelDeviceIds.add(deviceChannel.getDeviceId());
+            }
+        }
+        if (!channelDeviceIds.isEmpty()) {
+            int deleteCount = channelMapper.cleanOrphanChannelsByDeviceIds(new ArrayList<>(channelDeviceIds));
+            if (deleteCount > 0) {
+                log.info("[目录同步] 清理孤儿通道 {} 条, deviceDbId: {}, channelIds: {}", deleteCount, deviceDbId, channelDeviceIds);
+            }
+        }
         List<DeviceChannel> allChannels = channelMapper.queryAllChannelsForRefresh(deviceDbId);
         Map<String,DeviceChannel> allChannelMap = new HashMap<>();
         if (!allChannels.isEmpty()) {
@@ -621,7 +633,15 @@ public class DeviceChannelServiceImpl implements IDeviceChannelService {
     @Override
     public void addChannel(DeviceChannel channel) {
         channel.setDataType(ChannelDataType.GB28181);
-        channel.setDataDeviceId(channel.getDataDeviceId());
+        if (channel.getDataDeviceId() == null || channel.getDataDeviceId() <= 0) {
+            log.warn("[收到通道通知] 忽略未绑定设备的通道新增, channelId: {}", channel.getDeviceId());
+            return;
+        }
+        Device device = deviceMapper.query(channel.getDataDeviceId());
+        if (device == null) {
+            log.warn("[收到通道通知] 忽略所属设备不存在的通道新增, channelId: {}, dataDeviceId: {}", channel.getDeviceId(), channel.getDataDeviceId());
+            return;
+        }
         channelMapper.add(channel);
     }
 

--- a/src/test/java/com/genersoft/iot/vmp/gb28181/service/impl/DeviceChannelServiceImplTest.java
+++ b/src/test/java/com/genersoft/iot/vmp/gb28181/service/impl/DeviceChannelServiceImplTest.java
@@ -1,0 +1,78 @@
+package com.genersoft.iot.vmp.gb28181.service.impl;
+
+import com.genersoft.iot.vmp.gb28181.bean.Device;
+import com.genersoft.iot.vmp.gb28181.bean.DeviceChannel;
+import com.genersoft.iot.vmp.gb28181.dao.DeviceChannelMapper;
+import com.genersoft.iot.vmp.gb28181.dao.DeviceMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DeviceChannelServiceImplTest {
+
+    @Test
+    void addChannelShouldIgnoreOrphanGbChannel() {
+        DeviceChannelMapper channelMapper = mock(DeviceChannelMapper.class);
+
+        DeviceChannelServiceImpl service = new DeviceChannelServiceImpl();
+        ReflectionTestUtils.setField(service, "channelMapper", channelMapper);
+        ReflectionTestUtils.setField(service, "deviceMapper", mock(DeviceMapper.class));
+
+        DeviceChannel channel = new DeviceChannel();
+        channel.setDeviceId("34020000001320000001");
+        channel.setDataDeviceId(0);
+
+        service.addChannel(channel);
+
+        verify(channelMapper, never()).add(any(DeviceChannel.class));
+    }
+
+    @Test
+    void resetChannelsShouldCleanOrphanChannelsBeforeSave() {
+        DeviceChannelMapper channelMapper = mock(DeviceChannelMapper.class);
+        when(channelMapper.cleanOrphanChannelsByDeviceIds(any())).thenReturn(1);
+        when(channelMapper.queryAllChannelsForRefresh(12)).thenReturn(Collections.emptyList());
+        when(channelMapper.batchAdd(any())).thenReturn(1);
+
+        DeviceChannelServiceImpl service = new DeviceChannelServiceImpl();
+        ReflectionTestUtils.setField(service, "channelMapper", channelMapper);
+
+        DeviceChannel channel = new DeviceChannel();
+        channel.setDeviceId("34020000001320000001");
+        channel.setDataDeviceId(12);
+        channel.setStatus("ON");
+
+        service.resetChannels(12, List.of(channel));
+
+        verify(channelMapper).cleanOrphanChannelsByDeviceIds(eq(List.of("34020000001320000001")));
+        verify(channelMapper).batchAdd(any());
+    }
+
+    @Test
+    void addChannelShouldPersistWhenDeviceExists() {
+        DeviceChannelMapper channelMapper = mock(DeviceChannelMapper.class);
+        DeviceMapper deviceMapper = mock(DeviceMapper.class);
+        when(deviceMapper.query(12)).thenReturn(new Device());
+
+        DeviceChannelServiceImpl service = new DeviceChannelServiceImpl();
+        ReflectionTestUtils.setField(service, "channelMapper", channelMapper);
+        ReflectionTestUtils.setField(service, "deviceMapper", deviceMapper);
+
+        DeviceChannel channel = new DeviceChannel();
+        channel.setDeviceId("34020000001320000001");
+        channel.setDataDeviceId(12);
+
+        service.addChannel(channel);
+
+        verify(channelMapper).add(channel);
+    }
+}


### PR DESCRIPTION
问题说明:
- 国标设备在目录通知与目录同步时序交错时，可能先写入一条 data_device_id=0 的孤儿通道记录。
- 后续正式目录同步会再写入一条绑定真实设备的记录，导致同编号通道重复展示。
- 点播命中孤儿记录时，会因为无法反查所属设备而报 server internal error。

修改说明:
- 拦截 data_device_id<=0 或所属设备不存在的 GB28181 通道新增，避免孤儿记录继续落库。
- 在 resetChannels 目录同步前，按 channel device_id 清理历史孤儿通道，消除已有重复项。
- 补充单测覆盖孤儿通道拦截和同步清理逻辑。