### PR TITLE
修复预置位列表查询仅返回10条数据的问题

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/message/response/cmd/PresetQueryResponseMessageHandler.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/message/response/cmd/PresetQueryResponseMessageHandler.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.DelayQueue;
 import java.util.concurrent.TimeUnit;
 
+import static com.genersoft.iot.vmp.gb28181.utils.XmlUtil.getInteger;
 import static com.genersoft.iot.vmp.gb28181.utils.XmlUtil.getText;
 
 /**
@@ -81,7 +82,8 @@ public class PresetQueryResponseMessageHandler extends SIPRequestProcessorParent
                 }
                 return;
             }
-            int num = Integer.parseInt(presetListNumElement.attributeValue("Num"));
+        	Integer sumNum = getInteger(rootElement, "SumNum");
+        	int	num = sumNum == null ? Integer.parseInt(presetListNumElement.attributeValue("Num")) : sumNum.intValue();
             List<Preset> presetQuerySipReqList = new ArrayList<>();
             if (num > 0) {
                 for (Iterator<Element> presetIterator = presetListNumElement.elementIterator(); presetIterator.hasNext(); ) {
@@ -102,7 +104,7 @@ public class PresetQueryResponseMessageHandler extends SIPRequestProcessorParent
                 }
             }
             String sn = getText(element, "SN");
-            addCatch(cmdType + "_" + sn, num,  rootElement, presetQuerySipReqList);
+            addCatch(cmdType + "_" + sn, num, rootElement, presetQuerySipReqList);
             try {
                 responseAck(request, Response.OK);
             } catch (InvalidArgumentException | ParseException | SipException e) {


### PR DESCRIPTION
修复 commit https://github.com/648540858/wvp-GB28181-pro/commit/93724bac98fd510538d9fcce53bbcf9db544832b 错误地将 648540858/wvp-GB28181-pro#1946 修复预置位列表查询只能返回10条数据BUG逻辑删除的问题。

部分设备预置位列表查询一次消息仅返回10条数据，但有 `<SumNum>` 告知接收方预置点总数，应该先尝试使用 `SumNum`，获取不到时再回退使用现有的 `Num`，以解决无法获取完整预置位列表问题。