### PR TITLE
fix: add WebSocket sub_filter for mp4_record and fix ptzCruising preset label

### DIFF
--- a/docker/nginx/templates/nginx.conf.template
+++ b/docker/nginx/templates/nginx.conf.template
@@ -34,6 +34,10 @@ server {
         sub_filter "http://$original_host:80/mp4_record" "mp4_record";
         sub_filter "https://$original_host/mp4_record" "mp4_record";
         sub_filter "https://$original_host:443/mp4_record" "mp4_record";
+        sub_filter "ws://$original_host/mp4_record" "mp4_record";
+        sub_filter "ws://$original_host:80/mp4_record" "mp4_record";
+        sub_filter "wss://$original_host/mp4_record" "mp4_record";
+        sub_filter "wss://$original_host:443/mp4_record" "mp4_record";
         
         # 设置为off表示替换所有匹配项，而不仅仅是第一个
         sub_filter_once off;

--- a/web/src/views/common/channelPlayer/ptzCruising.vue
+++ b/web/src/views/common/channelPlayer/ptzCruising.vue
@@ -30,7 +30,7 @@
           <el-option
             v-for="item in allPresetList"
             :key="item.presetId"
-            :label="item.presetName"
+            :label="item.presetName ? item.presetName : item.presetId"
             :value="item"
           />
         </el-select>

--- a/web/src/views/common/channelPlayer/ptzCruising.vue
+++ b/web/src/views/common/channelPlayer/ptzCruising.vue
@@ -26,7 +26,7 @@
 
     <el-form v-if="selectPresetVisible" size="mini" :inline="true">
       <el-form-item>
-        <el-select v-model="selectPreset" placeholder="请选择预置点">
+        <el-select v-model="selectPreset" value-key="presetId" placeholder="请选择预置点">
           <el-option
             v-for="item in allPresetList"
             :key="item.presetId"

--- a/web/src/views/common/ptzCruising.vue
+++ b/web/src/views/common/ptzCruising.vue
@@ -30,7 +30,7 @@
           <el-option
             v-for="item in allPresetList"
             :key="item.presetId"
-            :label="item.presetName"
+            :label="item.presetName ? item.presetName : item.presetId"
             :value="item"
           />
         </el-select>

--- a/web/src/views/common/ptzCruising.vue
+++ b/web/src/views/common/ptzCruising.vue
@@ -26,7 +26,7 @@
 
     <el-form v-if="selectPresetVisible" size="mini" :inline="true">
       <el-form-item>
-        <el-select v-model="selectPreset" placeholder="请选择预置点">
+        <el-select v-model="selectPreset" value-key="presetId" placeholder="请选择预置点">
           <el-option
             v-for="item in allPresetList"
             :key="item.presetId"


### PR DESCRIPTION
**关联 Issue:** #2151

---

**Bug 1：nginx 模板缺少 mp4_record 的 ws/wss sub_filter**

`docker/nginx/templates/nginx.conf.template` 中 sub_filter 只处理了 `http://` 和 `https://` 的 mp4_record URL，缺少 `ws://` 和 `wss://` 规则。导致云端录像 WebSocket 播放时浏览器直接连接媒体服务器 IP 而非通过 nginx 代理，连接失败。

**Bug 2：云台巡航下拉菜单预置点名称显示异常**

`web/src/views/common/channelPlayer/ptzCruising.vue` 和 `web/src/views/common/ptzCruising.vue` 中，下拉菜单 `<el-option>` 的 `:label` 直接使用 `item.presetName`，当设备返回的预置点 `presetName` 为空时选项显示空白。已补上 `presetId` 作为 fallback。

**变更文件：**

- `docker/nginx/templates/nginx.conf.template` — 添加 4 行 ws/wss sub_filter
- `web/src/views/common/channelPlayer/ptzCruising.vue` — `:label` 增加 fallback
- `web/src/views/common/ptzCruising.vue` — `:label` 增加 fallback