### PR TITLE
fix: 修复 issue 2159 级联点播自定义 SSRC 鉴权 key 未刷新问题

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/service/impl/PlayServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/service/impl/PlayServiceImpl.java
@@ -859,6 +859,9 @@ public class PlayServiceImpl implements IPlayService {
             }
         }else {
             log.info("[Invite 200OK] 收到invite 200, 发现下级自定义了ssrc: {}", ssrcInResponse);
+            String oldStreamId = String.format("%08x", Long.parseLong(ssrcInfo.getSsrc())).toUpperCase();
+            String newStreamId = String.format("%08x", Long.parseLong(ssrcInResponse)).toUpperCase();
+            receiveRtpServerService.refreshAuthenticateInfo(oldStreamId, newStreamId);
             // ssrc 不一致
             if (mediaServerItem.isRtpEnable()) {
                 // 多端口

--- a/src/main/java/com/genersoft/iot/vmp/service/IReceiveRtpServerService.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/IReceiveRtpServerService.java
@@ -39,4 +39,6 @@ public interface IReceiveRtpServerService {
     void addAuthenticateInfo(String streamId, String streamReplace, Boolean enableAudio, Boolean enableMp4, Integer mp4MaxSecond);
 
     ResultForOnPublish getAuthenticateInfo(String streamId);
+
+    void refreshAuthenticateInfo(String oldStreamId, String newStreamId);
 }

--- a/src/main/java/com/genersoft/iot/vmp/service/impl/RtpServerServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/service/impl/RtpServerServiceImpl.java
@@ -406,4 +406,22 @@ public class RtpServerServiceImpl implements IReceiveRtpServerService {
          }
          return null;
      }
+
+     @Override
+     public void refreshAuthenticateInfo(String oldStreamId, String newStreamId) {
+         if (oldStreamId == null || newStreamId == null || oldStreamId.equals(newStreamId)) {
+             return;
+         }
+         String oldKey = String.format("%s:%s", VideoManagerConstants.RTP_AUTHENTICATE, oldStreamId);
+         Object obj = redisTemplate.opsForValue().get(oldKey);
+         if (obj instanceof ResultForOnPublish) {
+             String newKey = String.format("%s:%s", VideoManagerConstants.RTP_AUTHENTICATE, newStreamId);
+             redisTemplate.opsForValue().set(newKey, obj);
+             redisTemplate.expire(newKey, 60, TimeUnit.SECONDS);
+             redisTemplate.delete(oldKey);
+             log.info("[刷新RTP鉴权信息] {} -> {}", oldStreamId, newStreamId);
+         } else {
+             log.warn("[刷新RTP鉴权信息] 未找到旧key: {}", oldKey);
+         }
+     }
 }


### PR DESCRIPTION
## 概要
- 修复级联点播场景下，下级平台使用自定义 SSRC 时未同步刷新 RTP 鉴权 key 的问题
- 将该修复从原分支单独拣出，并基于最新 master 提交，避免混入其他改动

## 测试计划
- [ ] 未执行自动化测试
- [x] 待在级联点播场景下手动验证自定义 SSRC 时 RTP 鉴权 key 会同步刷新

Closes #2159

🤖 Generated with [Claude Code](https://claude.com/claude-code)