### PR TITLE
修复录制计划-编辑时的回显加载问题

### DIFF
--- a/web/src/views/common/weekTimePicker.vue
+++ b/web/src/views/common/weekTimePicker.vue
@@ -148,10 +148,17 @@ export default {
     }
   },
   watch: {
-    planArray: function(array) {
-      for (let i = 0; i < array.length; i++) {
-        this.weekData[i].data = array[i].data
-      }
+    planArray: {
+      handler(array) {
+        if (!array || !array.length) {
+          return
+        }
+        for (let i = 0; i < array.length; i++) {
+          this.weekData[i].data = array[i].data
+        }
+      },
+      deep: true,
+      immediate: true
     }
   },
   created() {


### PR DESCRIPTION
录制计划页面，首次打开页面点编辑按钮，时间选择器没有正常回显。原因是弹框打开后，组件已挂载，接口返回数据后子组件没有更新。