### PR TITLE
修复目录通道重复字段

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/bean/CommonGBChannel.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/bean/CommonGBChannel.java
@@ -257,12 +257,6 @@ public class CommonGBChannel {
                 if (this.getGbAddress() != null) {
                     content.append("<Address>" + this.getGbAddress() + "</Address>\n");
                 }
-                if (this.getGbRegisterWay() != null) {
-                    content.append("<RegisterWay>" + this.getGbRegisterWay() + "</RegisterWay>\n");
-                }
-                if (this.getGbSecrecy() != null) {
-                    content.append("<Secrecy>" + this.getGbSecrecy() + "</Secrecy>\n");
-                }
                 if (this.getGbParentId() != null) {
                     content.append("<ParentID>" + this.getGbParentId() + "</ParentID>\n");
                 }

--- a/src/test/java/com/genersoft/iot/vmp/gb28181/bean/CommonGBChannelTest.java
+++ b/src/test/java/com/genersoft/iot/vmp/gb28181/bean/CommonGBChannelTest.java
@@ -1,0 +1,44 @@
+package com.genersoft.iot.vmp.gb28181.bean;
+
+import com.genersoft.iot.vmp.gb28181.event.subscribe.catalog.CatalogEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CommonGBChannelTest {
+
+    @Test
+    void encodeCatalogAddForCameraChannelShouldNotDuplicateRegisterWayOrSecrecy() {
+        CommonGBChannel channel = new CommonGBChannel();
+        channel.setGbDeviceId("42010100001320000006");
+        channel.setGbName("camera");
+        channel.setGbManufacturer("Dahua");
+        channel.setGbModel("DH-SD2904-GN");
+        channel.setGbOwner("Owner");
+        channel.setGbCivilCode("420101");
+        channel.setGbAddress("address");
+        channel.setGbParentId("42010100001320001006");
+        channel.setGbParental(0);
+        channel.setGbSafetyWay(0);
+        channel.setGbRegisterWay(1);
+        channel.setGbSecrecy(0);
+        channel.setGbIpAddress("172.16.0.145");
+        channel.setGbPort(80);
+        channel.setGbStatus("ON");
+
+        String content = channel.encode(CatalogEvent.ADD, "42010100002000000001");
+
+        assertEquals(1, count(content, "<RegisterWay>"));
+        assertEquals(1, count(content, "<Secrecy>"));
+    }
+
+    private static int count(String value, String needle) {
+        int count = 0;
+        int index = 0;
+        while ((index = value.indexOf(needle, index)) >= 0) {
+            count++;
+            index += needle.length();
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## 变更内容

- 删除普通通道 Catalog XML 编码中提前输出的 RegisterWay 和 Secrecy 字段，保留后续规范字段位置的输出。
- 增加 CommonGBChannel 单元测试，覆盖 Catalog ADD 普通通道编码，防止 RegisterWay/Secrecy 重复输出。

## 问题原因

普通通道分支在 Address 后输出了一次 RegisterWay/Secrecy，随后在 ParentID、Parental、SafetyWay 后又输出同一组字段，导致上级收到的 Catalog NOTIFY/Response 中出现重复字段。

## 验证

- git diff --check
- 使用 IDEA 内置 Maven 编译测试代码：mvn -Dtest=CommonGBChannelTest -DskipTests=false -Dmaven.test.skip=false test
- 由于项目 surefire 配置硬编码 skipTests=true，使用 JUnit Platform Console 执行 CommonGBChannelTest，1 个测试通过。