### PR TITLE
fix: RecordInfoQueryMessageHandler非法SIP状态码导致内存泄漏与设备批量掉线

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/SIPRequestProcessorParent.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/SIPRequestProcessorParent.java
@@ -89,6 +89,12 @@ public abstract class SIPRequestProcessorParent {
 
 
 	public SIPResponse responseAck(SIPRequest sipRequest, int statusCode, String msg, ResponseAckExtraParam responseAckExtraParam) throws SipException, InvalidArgumentException, ParseException {
+		// 全局防御：校验SIP状态码合法性，防止非法状态码传入JAIN-SIP导致IllegalArgumentException
+		if (statusCode < 100 || statusCode > 699) {
+			log.error("[SIP响应] 非法状态码: {}，已替换为500 Server Internal Error。原始消息: {}", statusCode, msg);
+			statusCode = Response.SERVER_INTERNAL_ERROR; // 500
+		}
+
 		if (sipRequest.getToHeader().getTag() == null) {
 			sipRequest.getToHeader().setTag(SipUtils.getNewTag());
 		}

--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/message/query/cmd/RecordInfoQueryMessageHandler.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/message/query/cmd/RecordInfoQueryMessageHandler.java
@@ -144,11 +144,21 @@ public class RecordInfoQueryMessageHandler extends SIPRequestProcessorParent imp
                                 log.error("[命令发送失败] 录像查询回复: {}", e.getMessage());
                             }
                         }),(eventResult -> {
-                            // 查询失败
+                            // 查询失败 - 校验statusCode合法性，防止非法状态码导致IllegalArgumentException
                             try {
-                                responseAck(request, eventResult.statusCode, eventResult.msg);
+                                int statusCode = eventResult.statusCode;
+                                if (statusCode < 100 || statusCode > 699) {
+                                    log.warn("[录像查询失败] 收到非法SIP状态码: {}，通道: {}/{}，消息: {}，已替换为500",
+                                            statusCode, platform.getName(), channelId, eventResult.msg);
+                                    statusCode = Response.SERVER_INTERNAL_ERROR; // 500
+                                }
+                                responseAck(request, statusCode, eventResult.msg);
                             } catch (SipException | InvalidArgumentException | ParseException e) {
                                 log.error("[命令发送失败] 录像查询回复: {}", e.getMessage());
+                            } catch (Exception e) {
+                                // 兜底捕获所有异常，防止异常逃逸到Spring调度层导致无限重试
+                                log.error("[录像查询] 未预期的异常，通道: {}/{}: {}",
+                                        platform.getName(), channelId, e.getMessage(), e);
                             }
                         }));
             } catch (InvalidArgumentException | ParseException | SipException e) {


### PR DESCRIPTION
## 问题

`RecordInfoQueryMessageHandler.handleForPlatform` 的录像查询失败回调中，`eventResult.statusCode` 未做合法性校验。当上游平台返回异常结果时（如 statusCode=-1024），非法状态码直接传入 JAIN-SIP 的 `createResponse()`，触发 `IllegalArgumentException`。由于异常未被正确捕获，逃逸到 Spring 定时任务调度层，导致任务被反复触发执行，海量错误日志耗尽堆内存（16GB），引发频繁 Full GC（8196次/日志周期），最终所有设备 SIP 心跳超时、批量掉线、视频流全部中断。

## 异常堆栈

```
java.lang.IllegalArgumentException: Bad code -1024
  at gov.nist.javax.sip.message.SIPRequest.createResponse(...)
  at com.genersoft.iot.vmp.gb28181.transmit.event.request.SIPRequestProcessorParent.responseAck(...)
  at com.genersoft.iot.vmp.gb28181.transmit.event.request.impl.message.query.cmd.RecordInfoQueryMessageHandler.lambda$handleForPlatform$2(...)
  at org.springframework.scheduling.support.ScheduledMethodRunnable.runInternal(...)
```

## 复现步骤

1. 部署 WVP-PRO v2.7.4，配置向上级平台级联
2. 上级平台返回异常响应或查询超时
3. 日志中出现大量 `java.lang.IllegalArgumentException: Bad code -1024`
4. GC 日志中出现 `Pause Full (G1 Compaction Pause)` 和 `Evacuation Failure`
5. 所有设备陆续掉线，视频流全部中断

## 修复内容

1. **RecordInfoQueryMessageHandler.java**: 在失败回调中增加 statusCode 范围校验（100-699），非法值替换为 500 Server Internal Error；增加 `catch (Exception)` 兜底，防止异常逃逸到 Spring 调度层
2. **SIPRequestProcessorParent.java**: 在 `responseAck()` 方法入口增加全局状态码防御（100-699 校验），作为安全网防止其他模块的同类问题

## 修复效果

- 非法状态码被替换为 500，不再触发 IllegalArgumentException
- 定时任务不再无限重试，内存泄漏消除
- Full GC 频率恢复正常，设备 SIP 心跳稳定

## 环境信息

- WVP-PRO 版本: v2.7.4
- JDK: 21.0.2
- 堆内存: -Xms16g -Xmx16g
- GC: G1GC