### PR TITLE
修复部分查询用户接口返回时泄露密码问题并修复部分控制器文档描述

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/storager/dao/dto/User.java
+++ b/src/main/java/com/genersoft/iot/vmp/storager/dao/dto/User.java
@@ -1,9 +1,12 @@
 package com.genersoft.iot.vmp.storager.dao.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class User {
 
     private int id;
     private String username;
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
     private String createTime;
     private String updateTime;

--- a/src/main/java/com/genersoft/iot/vmp/vmanager/user/UserApiKeyController.java
+++ b/src/main/java/com/genersoft/iot/vmp/vmanager/user/UserApiKeyController.java
@@ -108,7 +108,7 @@ public class UserApiKeyController {
      * @return 分页ApiKey列表
      */
     @GetMapping("/userApiKeys")
-    @Operation(summary = "分页查询用户", security = @SecurityRequirement(name = JwtUtils.HEADER))
+    @Operation(summary = "分页查询用户ApiKey", security = @SecurityRequirement(name = JwtUtils.HEADER))
     @Parameter(name = "page", description = "当前页", required = true)
     @Parameter(name = "count", description = "每页查询数量", required = true)
     @Transactional

--- a/src/main/java/com/genersoft/iot/vmp/vmanager/user/UserController.java
+++ b/src/main/java/com/genersoft/iot/vmp/vmanager/user/UserController.java
@@ -50,7 +50,6 @@ public class UserController {
     @PostMapping("/login")
     @Operation(summary = "登录", description = "登录成功后返回AccessToken， 可以从返回值获取到也可以从响应头中获取到，" +
             "后续的请求需要添加请求头 'access-token'或者放在参数里")
-
     @Parameter(name = "username", description = "用户名", required = true)
     @Parameter(name = "password", description = "密码（32位md5加密）", required = true)
     public LoginUser login(HttpServletRequest request, HttpServletResponse response, @RequestParam String username, @RequestParam String password){
@@ -154,9 +153,8 @@ public class UserController {
     }
 
     @GetMapping("/all")
-    @Operation(summary = "查询用户", security = @SecurityRequirement(name = JwtUtils.HEADER))
+    @Operation(summary = "查询全部用户", security = @SecurityRequirement(name = JwtUtils.HEADER))
     public List<User> all(){
-        // 获取当前登录用户id
         return userService.getAllUsers();
     }
 
@@ -214,7 +212,7 @@ public class UserController {
     }
 
     @PostMapping("/userInfo")
-    @Operation(summary = "管理员修改普通用户密码")
+    @Operation(summary = "查询当前登录用户信息")
     public LoginUser getUserInfo() {
         // 获取当前登录用户id
         LoginUser userInfo = SecurityUtils.getUserInfo();


### PR DESCRIPTION
1、修复部分控制器错误的文档描述
2、当前部分用户接口，如 /api/user/all 通过 UserMapper.selectAll 查询全部字段后直接返回给前端，里面包含了用户密码，导致密码泄露。

https://github.com/648540858/wvp-GB28181-pro/blob/92ee9c38632a778facf3171d1afd14bb1f92b57d/src/main/java/com/genersoft/iot/vmp/storager/dao/UserMapper.java#L50-L52

一种方法是类似分页查询用户接口 /api/user/users 一样，不使用 u.* 返回全部字段，而是显式指定所需字段。

此PR中，为了防止后续其他地方直接返回 User 再次导致 password 意外泄露的可能，采用了序列化JSON时直接忽略 password 字段的方式，可以保证返回前端时不包含 password 但不影响作为 request body 请求体时 password 参数的传入。


| Before | After |
| :----: | :----: |
| <img width="1150" height="828" alt="image" src="https://github.com/user-attachments/assets/d14d5a56-d94e-4026-8ac2-2bd214f0584d" /> |  <img width="1130" height="691" alt="image" src="https://github.com/user-attachments/assets/5ee86fa9-afef-4a93-89c5-dd0b4bd5896a" /> |