### PR TITLE
Fix: 修复 getMediaList BUG，修复 streamInfo 获取 originType 属性 BUG

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/media/zlm/ZLMMediaNodeServerService.java
+++ b/src/main/java/com/genersoft/iot/vmp/media/zlm/ZLMMediaNodeServerService.java
@@ -196,7 +196,7 @@ public class ZLMMediaNodeServerService implements IMediaNodeServerService {
                     return streamInfoList;
                 }
                 for (int i = 0; i < zlmResult.getData().size(); i++) {
-                    JSONObject mediaJSON = zlmResult.getData().getJSONObject(0);
+                    JSONObject mediaJSON = zlmResult.getData().getJSONObject(i);
                     MediaInfo mediaInfo = MediaInfo.getInstance(mediaJSON, mediaServer, userSetting.getServerId());
                     StreamInfo streamInfo = getStreamInfoByAppAndStream(mediaServer, mediaInfo.getApp(),
                             mediaInfo.getStream(), mediaInfo, null, callId, true);

--- a/src/main/java/com/genersoft/iot/vmp/streamProxy/service/impl/StreamProxyServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/streamProxy/service/impl/StreamProxyServiceImpl.java
@@ -276,8 +276,8 @@ public class StreamProxyServiceImpl implements IStreamProxyService {
                 // 流媒体存在，数据库中不存在
                 continue;
             }
-            if (streamInfo.getOriginType() == OriginType.PULL.ordinal()
-                    || streamInfo.getOriginType() == OriginType.FFMPEG_PULL.ordinal()) {
+            if (streamInfo.getMediaInfo().getOriginType() == OriginType.PULL.ordinal()
+                    || streamInfo.getMediaInfo().getOriginType() == OriginType.FFMPEG_PULL.ordinal()) {
                 if (streamProxyMapForDb.get(key) != null) {
                     redisCatchStorage.addStream(mediaServer, "pull", streamInfo.getApp(), streamInfo.getStream(), streamInfo.getMediaInfo());
                     if ("OFF".equalsIgnoreCase(streamProxy.getGbStatus()) && streamProxy.getGbId() > 0) {

--- a/src/main/java/com/genersoft/iot/vmp/streamPush/service/impl/StreamPushServiceImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/streamPush/service/impl/StreamPushServiceImpl.java
@@ -547,9 +547,9 @@ public class StreamPushServiceImpl implements IStreamPushService {
         Map<String, StreamPush> result = new HashMap<>();
         for (StreamInfo streamInfo : streamInfoList) {
             // 不保存国标推理以及拉流代理的流
-            if (streamInfo.getOriginType() == OriginType.RTSP_PUSH.ordinal()
-                    || streamInfo.getOriginType() == OriginType.RTMP_PUSH.ordinal()
-                    || streamInfo.getOriginType() == OriginType.RTC_PUSH.ordinal() ) {
+            if (streamInfo.getMediaInfo().getOriginType() == OriginType.RTSP_PUSH.ordinal()
+                    || streamInfo.getMediaInfo().getOriginType() == OriginType.RTMP_PUSH.ordinal()
+                    || streamInfo.getMediaInfo().getOriginType() == OriginType.RTC_PUSH.ordinal() ) {
                 String key = streamInfo.getApp() + "_" + streamInfo.getStream();
                 StreamPush streamPushItem = result.get(key);
                 if (streamPushItem == null) {


### PR DESCRIPTION
1. update src/main/java/com/genersoft/iot/vmp/media/zlm/ZLMMediaNodeServerService.java 修复 getMediaList 响应数据 JSONArray 遍历BUG
2. update src/main/java/com/genersoft/iot/vmp/streamPush/service/impl/StreamPushServiceImpl.java 修复 handleJSON 函数中 streamInfo 对象 originType 属性获取方式，streamInfo 中 originType 是空值，修改为streamInfo.getMediaInfo().getOriginType()
3. update src/main/java/com/genersoft/iot/vmp/streamProxy/service/impl/StreamProxyServiceImpl.java 修复 zlmServerOnline 函数中 streamInfo 对象 originType 属性获取方式，streamInfo 中 originType 是空值，修改为streamInfo.getMediaInfo().getOriginType()