### PR TITLE
fix: 修复国标录像查询时重复时间段导致Duplicate key异常

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/message/response/cmd/RecordInfoResponseMessageHandler.java
+++ b/src/main/java/com/genersoft/iot/vmp/gb28181/transmit/event/request/impl/message/response/cmd/RecordInfoResponseMessageHandler.java
@@ -119,7 +119,10 @@ public class RecordInfoResponseMessageHandler extends SIPRequestProcessorParent 
                     }
                     Map<String, String> map = recordList.stream()
                             .filter(record -> record.getDeviceId() != null)
-                            .collect(Collectors.toMap(record -> record.getStartTime()+ record.getEndTime(), UJson::writeJson));
+                            .collect(Collectors.toMap(record -> record.getStartTime()+ record.getEndTime(), UJson::writeJson,(existing, replacement) -> {
+						log.warn("[国标录像] 发现重复录像记录，时间段: {}, 保留第一条", existing);
+						return existing;
+					}));
                     // 获取任务结果数据
                     String resKey = VideoManagerConstants.REDIS_RECORD_INFO_RES_PRE + channelId + sn;
                     redisTemplate.opsForHash().putAll(resKey, map);


### PR DESCRIPTION
问题描述：
- 设备返回的录像列表中存在相同开始和结束时间的记录
- WVP使用startTime+endTime作为Map的key
- Collectors.toMap()遇到重复key时抛出IllegalStateException

修复方案：
- 在Collectors.toMap()中添加合并函数
- 遇到重复记录时保留第一条并记录警告日志

影响范围：
- 仅影响国标录像查询功能
- 不会改变正常录像记录的处理逻辑